### PR TITLE
Add batch transaction support to XRPL service

### DIFF
--- a/.changeset/tangy-yaks-look.md
+++ b/.changeset/tangy-yaks-look.md
@@ -2,5 +2,4 @@
 "custody": patch
 ---
 
-Add batch transaction support to XRPL service  
-
+Add batch transaction support to XRPL service

--- a/.changeset/tangy-yaks-look.md
+++ b/.changeset/tangy-yaks-look.md
@@ -1,0 +1,6 @@
+---
+"custody": patch
+---
+
+Add batch transaction support to XRPL service  
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -171,6 +171,7 @@ export type {
 // xrpl types
 export type {
   CustodyAccountSet,
+  CustodyBatch,
   CustodyClawback,
   CustodyDepositPreauth,
   CustodyMpTokenAuthorize,

--- a/src/ripple-custody.ts
+++ b/src/ripple-custody.ts
@@ -146,6 +146,7 @@ import type {
 import {
   XrplService,
   type CustodyAccountSet,
+  type CustodyBatch,
   type CustodyClawback,
   type CustodyDepositPreauth,
   type CustodyMpTokenAuthorize,
@@ -914,6 +915,17 @@ export class RippleCustody {
       params: CustodyAccountSet,
       options?: XrplIntentOptions,
     ): Promise<Core_IntentResponse> => this.xrplService.accountSet(params, options),
+
+    /**
+     * Create an XRPL Batch transaction.
+     * @param params - The Batch transaction details
+     * @param options - Optional configuration for the Batch intent
+     * @returns The proposed intent response
+     */
+    batch: async (
+      params: CustodyBatch,
+      options?: XrplIntentOptions,
+    ): Promise<Core_IntentResponse> => this.xrplService.batch(params, options),
 
     /**
      * Create an XRPL raw sign.

--- a/src/services/xrpl/xrpl.service.ts
+++ b/src/services/xrpl/xrpl.service.ts
@@ -22,6 +22,7 @@ import type {
   BuildTransactionIntentProps,
   Core_XrplOperation,
   CustodyAccountSet,
+  CustodyBatch,
   CustodyClawback,
   CustodyDepositPreauth,
   CustodyMpTokenAuthorize,
@@ -146,6 +147,20 @@ export class XrplService {
     options: XrplIntentOptions = {},
   ): Promise<Core_IntentResponse> {
     return this.proposeXrplIntent({ ...accountSet, type: "AccountSet" }, options)
+  }
+
+  /**
+   * Creates and proposes a batch intent for an XRPL Batch transaction.
+   * @param batch - The batch transaction details
+   * @param options - Optional configuration for the batch intent
+   * @returns The proposed intent response
+   * @throws {CustodyError} If validation fails or the sender account is not found
+   */
+  public async batch(
+    batch: CustodyBatch,
+    options: XrplIntentOptions = {},
+  ): Promise<Core_IntentResponse> {
+    return this.proposeXrplIntent({ ...batch, type: "Batch" }, options)
   }
 
   /**

--- a/src/services/xrpl/xrpl.types.ts
+++ b/src/services/xrpl/xrpl.types.ts
@@ -100,9 +100,7 @@ export type CustodyAccountSet = Prettify<
 // Batch
 
 export type Core_XrplOperation_Batch = components["schemas"]["Core_XrplOperation_Batch"]
-export type CustodyBatch = Prettify<
-  Pick<Batch, "Account"> & Omit<Core_XrplOperation_Batch, "type">
->
+export type CustodyBatch = Prettify<Pick<Batch, "Account"> & Omit<Core_XrplOperation_Batch, "type">>
 
 // General
 

--- a/src/services/xrpl/xrpl.types.ts
+++ b/src/services/xrpl/xrpl.types.ts
@@ -1,5 +1,6 @@
 import type {
   AccountSet,
+  Batch,
   Clawback,
   DepositPreauth,
   MPTokenAuthorize,
@@ -94,6 +95,13 @@ export type CustodyOfferCreate = Prettify<
 export type Core_XrplOperation_AccountSet = components["schemas"]["Core_XrplOperation_AccountSet"]
 export type CustodyAccountSet = Prettify<
   Pick<AccountSet, "Account"> & Omit<Core_XrplOperation_AccountSet, "type">
+>
+
+// Batch
+
+export type Core_XrplOperation_Batch = components["schemas"]["Core_XrplOperation_Batch"]
+export type CustodyBatch = Prettify<
+  Pick<Batch, "Account"> & Omit<Core_XrplOperation_Batch, "type">
 >
 
 // General


### PR DESCRIPTION
  Introduce CustodyBatch type and batch() method following the existing
  transaction pattern (sendPayment, accountSet, etc.), and expose it
  through the xrpl namespace in RippleCustody.