### PR TITLE
fix: handle MPT amounts in Payment operation converter

### DIFF
--- a/.changeset/tasty-kings-drive.md
+++ b/.changeset/tasty-kings-drive.md
@@ -1,0 +1,6 @@
+---
+"custody": patch
+---
+
+Handle MPT (Multi-Purpose Token) amounts in the Payment operation converter.  
+

--- a/.changeset/tasty-kings-drive.md
+++ b/.changeset/tasty-kings-drive.md
@@ -2,5 +2,4 @@
 "custody": patch
 ---
 
-Handle MPT (Multi-Purpose Token) amounts in the Payment operation converter.  
-
+Handle MPT (Multi-Purpose Token) amounts in the Payment operation converter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
   New XRPL transaction types are supported automatically when the OpenAPI spec is regenerated — no new SDK method required.
 
   ### Other changes
+
   - `XrplService` now accepts an `XrplPorts` interface for I/O dependencies, enabling simpler testing with in-memory adapters instead of mock-heavy setups.
   - `DomainResolverService` has been removed. Its domain resolution and user validation logic is now internal to the HTTP port adapter.
   - `rawSign`, `rawSignAndWait`, `rawSignInnerBatch`, `rawSignInnerBatchAndWait`, and `getPublicKey` are unchanged.

--- a/src/services/xrpl/xrpl.adapters.test.ts
+++ b/src/services/xrpl/xrpl.adapters.test.ts
@@ -131,6 +131,22 @@ describe("rawTransactionsToInnerTransactions", () => {
       const [result] = rawTransactionsToInnerTransactions(makeRawTransactions(tx))
       expect(result.operation).not.toHaveProperty("destinationTag")
     })
+
+    it("converts MPT payment", () => {
+      const tx: RawTx = {
+        ...baseTx,
+        TransactionType: "Payment",
+        Destination: "rDest456",
+        Amount: { mpt_issuance_id: "00000001ABC123", value: "500" },
+      }
+      const [result] = rawTransactionsToInnerTransactions(makeRawTransactions(tx))
+      expect(result.operation).toEqual({
+        type: "Payment",
+        destination: { type: "Address", address: "rDest456" },
+        amount: "500",
+        currency: { type: "MultiPurposeToken", issuanceId: "00000001ABC123" },
+      })
+    })
   })
 
   describe("OfferCreate", () => {

--- a/src/services/xrpl/xrpl.adapters.ts
+++ b/src/services/xrpl/xrpl.adapters.ts
@@ -9,6 +9,7 @@ import {
   OfferCreateFlags,
   TrustSetFlags,
 } from "xrpl"
+import { isString } from "../../helpers/index.js"
 import type {
   CustodyAccountSetFlag,
   CustodyBatchSigner,
@@ -141,7 +142,7 @@ const txToOperation = (tx: RawTx): CustodyOperation => {
   switch (tx.TransactionType) {
     case "Payment": {
       const amount = tx.Amount
-      if (typeof amount === "string") {
+      if (isString(amount)) {
         // XRP drops
         return {
           type: "Payment",

--- a/src/services/xrpl/xrpl.adapters.ts
+++ b/src/services/xrpl/xrpl.adapters.ts
@@ -140,21 +140,29 @@ const mpTokenIssuanceSetFlagsToStrings = (
 const txToOperation = (tx: RawTx): CustodyOperation => {
   switch (tx.TransactionType) {
     case "Payment": {
-      const iou = typeof tx.Amount !== "string" ? (tx.Amount as IssuedCurrencyAmount) : null
+      const amount = tx.Amount
+      if (typeof amount === "string") {
+        // XRP drops
+        return {
+          type: "Payment",
+          destination: { type: "Address", address: tx.Destination },
+          amount,
+          ...(tx.DestinationTag !== undefined && { destinationTag: tx.DestinationTag }),
+        }
+      }
+      const isMPT = "mpt_issuance_id" in amount
       return {
         type: "Payment",
         destination: { type: "Address", address: tx.Destination },
-        amount: iou ? iou.value : (tx.Amount as string),
-        ...(tx.DestinationTag !== undefined && {
-          destinationTag: tx.DestinationTag,
-        }),
-        ...(iou && {
-          currency: {
-            type: "Currency",
-            code: iou.currency,
-            issuer: iou.issuer,
-          },
-        }),
+        amount: amount.value,
+        ...(tx.DestinationTag !== undefined && { destinationTag: tx.DestinationTag }),
+        currency: isMPT
+          ? { type: "MultiPurposeToken" as const, issuanceId: amount.mpt_issuance_id }
+          : {
+              type: "Currency" as const,
+              code: (amount as IssuedCurrencyAmount).currency,
+              issuer: (amount as IssuedCurrencyAmount).issuer,
+            },
       }
     }
     case "OfferCreate":


### PR DESCRIPTION
The Payment case in txToOperation only handled XRP (string) and IOU
(IssuedCurrencyAmount). MPT amounts (which carry mpt_issuance_id) were
falling through to the IOU branch, producing incorrect currency output.
