### PR TITLE
feat: return batchSigner in both xrpl.js and custody formats from rawSignInnerBatchAndWait

### DIFF
--- a/.changeset/nine-ads-bake.md
+++ b/.changeset/nine-ads-bake.md
@@ -1,0 +1,6 @@
+---
+"custody": minor
+---
+
+rawSignInnerBatchAndWait now returns batchSigner (xrpl.js BatchSigner format) and  
+

--- a/.changeset/nine-ads-bake.md
+++ b/.changeset/nine-ads-bake.md
@@ -2,5 +2,12 @@
 "custody": minor
 ---
 
-rawSignInnerBatchAndWait now returns batchSigner (xrpl.js BatchSigner format) and  
+rawSignInnerBatchAndWait now returns batchSigner (xrpl.js BatchSigner format) and custodyBatchSigner (Ripple Custody API format) alongside the existing signature and signingPubKey fields. This removes the need for callers to manually construct BatchSigner objects or call batchSignersToCustodyBatchSigners after signing.
 
+Changes
+
+- src/services/xrpl/xrpl.types.ts — Added RawSignInnerBatchAndWaitResult type extending RawSignAndWaitResult with batchSigner and custodyBatchSigner fields.
+- src/services/xrpl/xrpl.service.ts — Updated rawSignInnerBatchAndWait to return the new type, constructing both batch signer formats from the signer address, public key, and signature.
+- src/index.ts — Exported RawSignInnerBatchAndWaitResult.
+- src/services/xrpl/xrpl.service.test.ts — Extended test to verify both batchSigner and custodyBatchSigner are returned correctly.
+- examples/xrpl/batch/multi-accounts/index.ts — Added example demonstrating the multi-account batch flow using the new return fields.

--- a/examples/xrpl/batch/multi-accounts/index.ts
+++ b/examples/xrpl/batch/multi-accounts/index.ts
@@ -12,8 +12,8 @@ import { rawTransactionsToInnerTransactions, RippleCustody } from "../../../../s
  * 5. Convert inner transactions and batch signers to the Custody API format
  * 6. Propose the Batch intent to Ripple Custody for submission
  *
- * In this example, ACCOUNT_2 and ACCOUNT_3 are the inner signers (they each
- * have a transaction inside the batch), while ACCOUNT_4 is the batch submitter.
+ * In this example, ACCOUNT_1 and ACCOUNT_2 are the inner signers (they each
+ * have a transaction inside the batch), while ACCOUNT_3 is the batch submitter.
  */
 const submitMultiAccountBatch = async () => {
   try {

--- a/examples/xrpl/batch/multi-accounts/index.ts
+++ b/examples/xrpl/batch/multi-accounts/index.ts
@@ -1,0 +1,120 @@
+import { type Batch, BatchFlags, Client, GlobalFlags, type Payment, xrpToDrops } from "xrpl"
+import { rawTransactionsToInnerTransactions, RippleCustody } from "../../../../src/index"
+
+/**
+ * Example: Submit a Batch transaction with multiple inner accounts using Ripple Custody
+ *
+ * This demonstrates the complete flow for a multi-account Batch transaction:
+ * 1. Initialize the custody client and an XRPL client
+ * 2. Construct inner transactions from different accounts
+ * 3. Build and autofill the Batch transaction via the XRPL client
+ * 4. Collect raw signatures from each inner account via Ripple Custody
+ * 5. Convert inner transactions and batch signers to the Custody API format
+ * 6. Propose the Batch intent to Ripple Custody for submission
+ *
+ * In this example, ACCOUNT_2 and ACCOUNT_3 are the inner signers (they each
+ * have a transaction inside the batch), while ACCOUNT_4 is the batch submitter.
+ */
+const submitMultiAccountBatch = async () => {
+  try {
+    // Initialize the Ripple Custody client
+    const custody = new RippleCustody({
+      apiUrl: "https://custody-api-url",
+      authUrl: "https://custody-auth-url/token",
+      privateKey: process.env.PRIVATE_KEY ?? "",
+      publicKey: process.env.PUBLIC_KEY ?? "",
+    })
+
+    // Accounts involved in this batch
+    const ACCOUNT_1 = "r..." // Inner signer 1
+    const ACCOUNT_2 = "r..." // Inner signer 2
+    const ACCOUNT_3 = "r..." // Batch submitter
+
+    // Connect to the XRPL to autofill transaction fields (Sequence, Fee, etc.)
+    const xrplClient = new Client("wss://xrpl-node-url")
+    await xrplClient.connect()
+
+    // ── 1. Construct inner transactions ──────────────────────────
+
+    // Each inner transaction must include the tfInnerBatchTxn flag
+    const payment1: Payment = {
+      Account: ACCOUNT_1,
+      TransactionType: "Payment",
+      Destination: ACCOUNT_2,
+      Amount: xrpToDrops(0.016),
+      Flags: GlobalFlags.tfInnerBatchTxn,
+    }
+
+    const payment2: Payment = {
+      Account: ACCOUNT_2,
+      TransactionType: "Payment",
+      Destination: ACCOUNT_1,
+      Amount: xrpToDrops(0.025),
+      Flags: GlobalFlags.tfInnerBatchTxn,
+    }
+
+    // ── 2. Build and autofill the Batch transaction ──────────────
+
+    const batch: Batch = {
+      Account: ACCOUNT_3,
+      TransactionType: "Batch",
+      Flags: BatchFlags.tfAllOrNothing,
+      RawTransactions: [{ RawTransaction: payment1 }, { RawTransaction: payment2 }],
+    }
+
+    // The second argument (signerCount) tells autofill how many signers to
+    // account for when computing the fee
+    const autofilledBatch = await xrplClient.autofill(batch, 2)
+
+    // ── 3. Collect raw signatures from each inner account ────────
+
+    // rawSignInnerBatchAndWait returns:
+    //   - signature / signingPubKey  (raw hex values)
+    //   - batchSigner                (xrpl.js BatchSigner format)
+    //   - custodyBatchSigner         (Ripple Custody API format)
+    const signer1 = await custody.xrpl.rawSignInnerBatchAndWait(autofilledBatch, ACCOUNT_1)
+    const signer2 = await custody.xrpl.rawSignInnerBatchAndWait(autofilledBatch, ACCOUNT_2)
+
+    console.log("Signer 2 (xrpl.js format):", signer1.batchSigner)
+    console.log("Signer 3 (xrpl.js format):", signer2.batchSigner)
+
+    // ── 4. Convert to Ripple Custody API format ──────────────────
+
+    // Convert inner transactions from xrpl.js RawTransactions to the
+    // Custody API innerTransactions format
+    const innerTransactions = rawTransactionsToInnerTransactions(autofilledBatch.RawTransactions)
+
+    // The custodyBatchSigner fields are already in the Custody API format,
+    // so we can use them directly
+    const batchSigners = [signer1.custodyBatchSigner, signer2.custodyBatchSigner]
+
+    // ── 5. Propose the Batch intent to Ripple Custody ────────────
+
+    const { requestId } = await custody.xrpl.proposeIntent({
+      Account: ACCOUNT_3,
+      operation: {
+        type: "Batch",
+        innerTransactions,
+        batchSigners,
+        executionMode: "AllOrNothing",
+      },
+    })
+
+    console.log("Batch intent proposed, requestId:", requestId)
+
+    // Retrieve the domain ID to poll for the intent result
+    const me = await custody.users.me()
+    const domainId = me.domains[0].id
+
+    // Wait for the intent to be processed and retrieve the final result
+    const intent = await custody.intents.getAndWait({ domainId, intentId: requestId })
+
+    console.dir(intent, { depth: null })
+
+    await xrplClient.disconnect()
+  } catch (error) {
+    console.log(error)
+  }
+}
+
+submitMultiAccountBatch()

--- a/src/index.ts
+++ b/src/index.ts
@@ -189,6 +189,7 @@ export type {
   CustodyTrustline,
   RawSignAndWaitOptions,
   RawSignAndWaitResult,
+  RawSignInnerBatchAndWaitResult,
   RawSignInnerBatchOptions,
   WaitForSignatureOptions,
   XrplIntentOptions,

--- a/src/ripple-custody.ts
+++ b/src/ripple-custody.ts
@@ -21,6 +21,7 @@ import {
   type Core_XrplOperation,
   type RawSignAndWaitOptions,
   type RawSignAndWaitResult,
+  type RawSignInnerBatchAndWaitResult,
   type RawSignInnerBatchOptions,
   type XrplIntentOptions,
 } from "./services/xrpl/index.js"
@@ -160,7 +161,7 @@ export class RippleCustody {
       batch: Batch,
       signerAddress: string,
       options?: RawSignInnerBatchOptions,
-    ): Promise<RawSignAndWaitResult> =>
+    ): Promise<RawSignInnerBatchAndWaitResult> =>
       this.xrplService.rawSignInnerBatchAndWait(batch, signerAddress, options),
 
     /**

--- a/src/services/xrpl/xrpl.service.test.ts
+++ b/src/services/xrpl/xrpl.service.test.ts
@@ -843,6 +843,22 @@ describe("XrplService", () => {
 
       expect(result.signature).toBe("AABBCCDD")
       expect(result.signingPubKey).toBe(expectedCompressedKey)
+
+      // xrpl.js BatchSigner format
+      expect(result.batchSigner).toEqual({
+        BatchSigner: {
+          Account: mockAddress,
+          SigningPubKey: expectedCompressedKey,
+          TxnSignature: "AABBCCDD",
+        },
+      })
+
+      // Ripple Custody format
+      expect(result.custodyBatchSigner).toEqual({
+        account: mockAddress,
+        signingPubKey: expectedCompressedKey,
+        txnSignature: "AABBCCDD",
+      })
     })
 
     it("should throw CustodyError on timeout", async () => {

--- a/src/services/xrpl/xrpl.service.ts
+++ b/src/services/xrpl/xrpl.service.ts
@@ -18,6 +18,7 @@ import type {
   IntentContext,
   RawSignAndWaitOptions,
   RawSignAndWaitResult,
+  RawSignInnerBatchAndWaitResult,
   RawSignInnerBatchOptions,
   WaitForSignatureOptions,
   XrplIntentOptions,
@@ -208,7 +209,7 @@ export class XrplService {
     batch: Batch,
     signerAddress: string,
     options: RawSignInnerBatchOptions = {},
-  ): Promise<RawSignAndWaitResult> {
+  ): Promise<RawSignInnerBatchAndWaitResult> {
     this.validateBatchSigner(batch, signerAddress)
 
     const context = await this.resolveInnerBatchContext(signerAddress, options)
@@ -229,7 +230,22 @@ export class XrplService {
       options.polling,
     )
 
-    return { signature, signingPubKey }
+    return {
+      signature,
+      signingPubKey,
+      batchSigner: {
+        BatchSigner: {
+          Account: signerAddress,
+          SigningPubKey: signingPubKey,
+          TxnSignature: signature,
+        },
+      },
+      custodyBatchSigner: {
+        account: signerAddress,
+        signingPubKey,
+        txnSignature: signature,
+      },
+    }
   }
 
   /**

--- a/src/services/xrpl/xrpl.types.ts
+++ b/src/services/xrpl/xrpl.types.ts
@@ -1,6 +1,7 @@
 import type {
   AccountSet,
   Batch,
+  BatchSigner,
   Clawback,
   DepositPreauth,
   MPTokenAuthorize,
@@ -187,13 +188,24 @@ export type RawSignAndWaitOptions = XrplIntentOptions & {
 }
 
 /**
- * Result of rawSignAndWait / rawSignInnerBatchAndWait.
+ * Result of rawSignAndWait.
  */
 export type RawSignAndWaitResult = {
   /** The signature in uppercase hex */
   signature: string
   /** The compressed secp256k1 public key in uppercase hex */
   signingPubKey: string
+}
+
+/**
+ * Result of rawSignInnerBatchAndWait.
+ * Extends RawSignAndWaitResult with batch signer representations.
+ */
+export type RawSignInnerBatchAndWaitResult = RawSignAndWaitResult & {
+  /** The batch signer in xrpl.js format */
+  batchSigner: BatchSigner
+  /** The batch signer in Ripple Custody API format */
+  custodyBatchSigner: CustodyBatchSigner
 }
 
 type BatchSignerLookup = { accountId?: never; ledgerId?: never }


### PR DESCRIPTION
Add RawSignInnerBatchAndWaitResult type that extends RawSignAndWaitResult with batchSigner (xrpl.js BatchSigner) and custodyBatchSigner (CustodyBatchSigner), so callers don't need to manually construct these from the raw signature.