### PR TITLE
fix: flatten manifest polling into a single retry loop to handle 404s correctly

### DIFF
--- a/.changeset/olive-suns-rush.md
+++ b/.changeset/olive-suns-rush.md
@@ -1,0 +1,14 @@
+---
+"custody": patch
+---
+
+fix: flatten manifest polling retry logic in waitForManifestSignature
+
+The nested `getManifestWithRetry` loop would throw a 404 that bypassed the outer  
+ `waitForManifestSignature` retry loop, causing `rawSignAndWait` and  
+ `rawSignInnerBatchAndWait` to fail immediately when the manifest wasn't ready yet.
+
+- Merged `getManifestWithRetry` into `waitForManifestSignature` as a single retry loop
+  that handles both 404s and missing signatures
+- Removed `notFoundRetries` and `notFoundIntervalMs` from `WaitForSignatureOptions`
+- Changed `maxRetries` default from 10 to 3

--- a/.changeset/olive-suns-rush.md
+++ b/.changeset/olive-suns-rush.md
@@ -4,11 +4,8 @@
 
 fix: flatten manifest polling retry logic in waitForManifestSignature
 
-The nested `getManifestWithRetry` loop would throw a 404 that bypassed the outer  
- `waitForManifestSignature` retry loop, causing `rawSignAndWait` and  
- `rawSignInnerBatchAndWait` to fail immediately when the manifest wasn't ready yet.
+The nested `getManifestWithRetry` loop would throw a 404 that bypassed the outer `waitForManifestSignature` retry loop, causing `rawSignAndWait` and `rawSignInnerBatchAndWait` to fail immediately when the manifest wasn't ready yet.
 
-- Merged `getManifestWithRetry` into `waitForManifestSignature` as a single retry loop
-  that handles both 404s and missing signatures
+- Merged `getManifestWithRetry` into `waitForManifestSignature` as a single retry loop that handles both 404s and missing signatures
 - Removed `notFoundRetries` and `notFoundIntervalMs` from `WaitForSignatureOptions`
 - Changed `maxRetries` default from 10 to 3

--- a/src/services/xrpl/xrpl.service.test.ts
+++ b/src/services/xrpl/xrpl.service.test.ts
@@ -741,7 +741,7 @@ describe("XrplService", () => {
 
       const tx = { ...mockXrplTransaction, SigningPubKey: "PK" }
       const result = await service.rawSignAndWait(tx, {
-        polling: { maxRetries: 1, intervalMs: 0, notFoundRetries: 2, notFoundIntervalMs: 0 },
+        polling: { maxRetries: 2, intervalMs: 0 },
       })
 
       expect(result.signature).toBe("AABBCCDD")

--- a/src/services/xrpl/xrpl.service.ts
+++ b/src/services/xrpl/xrpl.service.ts
@@ -349,6 +349,8 @@ export class XrplService {
 
   /**
    * Polls the manifest until a signature is available, then returns it as uppercase hex.
+   * Handles both the manifest not existing yet (404) and the manifest existing
+   * but not yet having a signature.
    * @private
    */
   private async waitForManifestSignature(
@@ -357,26 +359,22 @@ export class XrplService {
     manifestId: string,
     options: WaitForSignatureOptions = {},
   ): Promise<string> {
-    const {
-      maxRetries = 10,
-      intervalMs = 3000,
-      notFoundRetries = 3,
-      notFoundIntervalMs = 1000,
-      onAttempt,
-    } = options
+    const { maxRetries = 3, intervalMs = 3000, onAttempt } = options
 
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
       onAttempt?.(attempt)
 
-      const manifest = await this.getManifestWithRetry(
-        { domainId, accountId, manifestId },
-        notFoundRetries,
-        notFoundIntervalMs,
-      )
+      try {
+        const manifest = await this.ports.getManifest(domainId, accountId, manifestId)
 
-      const { value } = manifest.data
-      if (value && value.type === "Unsafe") {
-        return Buffer.from(value.signature, "base64").toString("hex").toUpperCase()
+        const { value } = manifest.data
+        if (value && value.type === "Unsafe") {
+          return Buffer.from(value.signature, "base64").toString("hex").toUpperCase()
+        }
+      } catch (error) {
+        if (!(error instanceof CustodyError && error.statusCode === 404)) {
+          throw error
+        }
       }
 
       if (attempt < maxRetries) {
@@ -387,35 +385,6 @@ export class XrplService {
     throw new CustodyError({
       reason: "Manifest signature not available after maximum retries",
     })
-  }
-
-  /**
-   * Fetches a manifest with retry logic for 404 errors.
-   * @private
-   */
-  private async getManifestWithRetry(
-    params: { domainId: string; accountId: string; manifestId: string },
-    maxRetries: number,
-    intervalMs: number,
-  ) {
-    let lastError: Error | undefined
-
-    for (let attempt = 1; attempt <= maxRetries; attempt++) {
-      try {
-        return await this.ports.getManifest(params.domainId, params.accountId, params.manifestId)
-      } catch (error) {
-        if (error instanceof CustodyError && error.statusCode === 404) {
-          lastError = error
-          if (attempt < maxRetries) {
-            await sleep(intervalMs)
-          }
-          continue
-        }
-        throw error
-      }
-    }
-
-    throw lastError
   }
 
   /**

--- a/src/services/xrpl/xrpl.types.ts
+++ b/src/services/xrpl/xrpl.types.ts
@@ -167,14 +167,10 @@ export type BuildTransactionIntentProps = {
  * Options for polling the manifest signature after a raw sign intent.
  */
 export type WaitForSignatureOptions = {
-  /** Maximum number of polling attempts (default: 10) */
+  /** Maximum number of polling attempts (default: 3) */
   maxRetries?: number
   /** Interval between polling attempts in milliseconds (default: 3000) */
   intervalMs?: number
-  /** Maximum retries when manifest returns 404 (default: 3) */
-  notFoundRetries?: number
-  /** Interval between 404 retries in milliseconds (default: 1000) */
-  notFoundIntervalMs?: number
   /** Callback on each polling attempt */
   onAttempt?: (attempt: number) => void
 }


### PR DESCRIPTION
The nested getManifestWithRetry inner loop would throw a 404 that bypassed the outer waitForManifestSignature loop, causing immediate failure when the manifest wasn't ready yet. Merged both loops into one so 404s are retried alongside missing-signature checks.