### PR TITLE
fix: guard against undefined body in ApiService.post() signature check

### DIFF
--- a/.changeset/curly-yaks-sleep.md
+++ b/.changeset/curly-yaks-sleep.md
@@ -1,0 +1,6 @@
+---
+"custody": patch
+---
+
+fix: guard against undefined body in `ApiService.post()` signature check  
+

--- a/.changeset/curly-yaks-sleep.md
+++ b/.changeset/curly-yaks-sleep.md
@@ -2,5 +2,6 @@
 "custody": patch
 ---
 
-fix: guard against undefined body in `ApiService.post()` signature check  
+fix: guard against undefined body in `ApiService.post()` signature check
 
+POST requests with no body (e.g. `userInvitations.complete`, `cancel`, `renew`) crashed with `Cannot read properties of undefined (reading 'signature')` because the signing logic accessed `body.signature` without a null check.

--- a/src/services/apis/api.service.test.ts
+++ b/src/services/apis/api.service.test.ts
@@ -431,6 +431,16 @@ MC4CAQAwBQYDK2VwBCIEIOrNTK/ChGQUdwitzdtwnhxfaBgRhR7vQaUxwXWTptnL
         expect((error as CustodyError).message).toBe("Serialization failed")
       }
     })
+
+    it("should skip signing when body is undefined", async () => {
+      const mockResponse = { data: { success: true } }
+      mockAxiosInstance.post.mockResolvedValue(mockResponse)
+
+      const result = await apiService.post("/test-endpoint", undefined)
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith("/test-endpoint", undefined, undefined)
+      expect(result).toEqual(mockResponse.data)
+    })
   })
 
   describe("response interceptor (401 retry)", () => {

--- a/src/services/apis/api.service.ts
+++ b/src/services/apis/api.service.ts
@@ -156,7 +156,7 @@ export class ApiService {
   public async post<T>(url: string, body: any, config?: AxiosRequestConfig): Promise<T> {
     try {
       // Sign the request if signature is missing
-      if (!body.signature || body.signature === "") {
+      if (body && (!body.signature || body.signature === "")) {
         // Canonicalize the request body
         // @ts-expect-error canonicalize works fine but has complex types
         const canonicalizedRequest = canonicalize(body.request)


### PR DESCRIPTION
POST requests with no body (e.g. userInvitations.complete/cancel/renew) crashed with "Cannot read properties of undefined (reading 'signature')" because the signing logic accessed body.signature without a null check.