### PR TITLE
Support for 1.34

### DIFF
--- a/.changeset/tasty-aliens-love.md
+++ b/.changeset/tasty-aliens-love.md
@@ -3,3 +3,5 @@
 ---
 
 chore: remove Batch transaction support — disable rawSignInnerBatch, rawSignInnerBatchAndWait, batchSignersToCustodyBatchSigners, and rawTransactionsToInnerTransactions until Batch is re-supported
+
+feat(accounts): add compliance configuration endpoints — `listComplianceConfigurations`, `getComplianceConfiguration`, and `upsertComplianceConfiguration` on the accounts namespace, plus a new `put()` method on `ApiService` and `TypedTransport` to support the PUT verb.

--- a/.changeset/tasty-aliens-love.md
+++ b/.changeset/tasty-aliens-love.md
@@ -1,0 +1,5 @@
+---
+"custody": minor
+---
+
+chore: remove Batch transaction support — disable rawSignInnerBatch, rawSignInnerBatchAndWait, batchSignersToCustodyBatchSigners, and rawTransactionsToInnerTransactions until Batch is re-supported

--- a/examples/xrpl/batch/multi-accounts/index.txt
+++ b/examples/xrpl/batch/multi-accounts/index.txt
@@ -1,3 +1,6 @@
+// Batch is not part of an official Ripple Custody release yet, hence this file is using a .txt extension for now.
+// When the official release supports it, the file will be renamed to .ts and we will make sure the script works
+
 import { type Batch, BatchFlags, Client, GlobalFlags, type Payment, xrpToDrops } from "xrpl"
 import { rawTransactionsToInnerTransactions, RippleCustody } from "../../../../src/index"
 

--- a/openapi/Ripple-Custody-v1-OpenAPI.json
+++ b/openapi/Ripple-Custody-v1-OpenAPI.json
@@ -7,7 +7,7 @@
       "url": "images/ripple-custody.png",
       "altText": "Ripple Custody logo"
     },
-    "x-app-version": "1.32.4"
+    "x-app-version": "1.34.1"
   },
   "paths": {
     "/v1/backups/{backupId}": {
@@ -1726,6 +1726,250 @@
         ]
       }
     },
+    "/v1/domains/{domainId}/compliance-configurations": {
+      "get": {
+        "tags": ["Accounts"],
+        "summary": "List compliance configurations for all accounts in a domain",
+        "operationId": "listComplianceConfigurations",
+        "parameters": [
+          {
+            "name": "domainId",
+            "in": "path",
+            "description": "Unique identifier for the domain.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "The number of entities to return.",
+            "schema": {
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "startingAfter",
+            "in": "query",
+            "description": "Entity id used to the determine beginning of query results.",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Core_ComplianceConfigurationsCollection"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "One of: Domain locked (DomainLockedError); Requester locked (RequesterLockedError)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Core_ErrorMessage"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "One of: Invalid JWT (InvalidJwtError); User not authorized (PermissionDeniedError)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Core_ErrorMessage"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Entity or Domain not found (EntityNotFoundError)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Core_ErrorMessage"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "httpAuth": []
+          }
+        ]
+      }
+    },
+    "/v1/domains/{domainId}/accounts/{accountId}/compliance-configuration": {
+      "get": {
+        "tags": ["Accounts"],
+        "summary": "Get compliance configuration for an account",
+        "operationId": "getComplianceConfiguration",
+        "parameters": [
+          {
+            "name": "domainId",
+            "in": "path",
+            "description": "Unique identifier for the domain.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "accountId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Core_ComplianceConfiguration"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "One of: Domain locked (DomainLockedError); Requester locked (RequesterLockedError)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Core_ErrorMessage"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "One of: Invalid JWT (InvalidJwtError); User not authorized (PermissionDeniedError)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Core_ErrorMessage"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Entity or Domain not found (EntityNotFoundError)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Core_ErrorMessage"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "httpAuth": []
+          }
+        ]
+      },
+      "put": {
+        "tags": ["Accounts"],
+        "summary": "Create or update compliance configuration for an account",
+        "operationId": "upsertComplianceConfiguration",
+        "parameters": [
+          {
+            "name": "domainId",
+            "in": "path",
+            "description": "Unique identifier for the domain.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "accountId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Core_UpsertComplianceConfigurationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Core_ComplianceConfiguration"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "One of: Domain locked (DomainLockedError); Invalid request (InvalidRequestError); Requester locked (RequesterLockedError)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Core_ErrorMessage"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "One of: Invalid JWT (InvalidJwtError); User not authorized (PermissionDeniedError)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Core_ErrorMessage"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Entity or Domain not found (EntityNotFoundError)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Core_ErrorMessage"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "httpAuth": []
+          }
+        ]
+      }
+    },
     "/v1/domains/{domainId}/accounts/{accountId}": {
       "get": {
         "tags": ["Accounts"],
@@ -2641,7 +2885,7 @@
           {
             "name": "ledgerId",
             "in": "query",
-            "description": "Updates only balances with the given ledger id. Reduces execution time.",
+            "description": "Updates only balances for native and validated tickers with the given ledger id. Non-validated token tickers are excluded. Reduces execution time.",
             "schema": {
               "minLength": 1,
               "type": "string"
@@ -3378,11 +3622,21 @@
           {
             "name": "quarantined",
             "in": "query",
-            "description": "Return entities matching given quarantined status.",
+            "description": "Deprecated: use quarantineStatus instead. Return entities matching given quarantined status.",
+            "deprecated": true,
             "schema": {
               "type": "boolean"
             },
             "example": "true"
+          },
+          {
+            "name": "quarantineStatus",
+            "in": "query",
+            "description": "Return entities matching given quarantine status. Values: Quarantined, Released, Skipped.",
+            "schema": {
+              "$ref": "#/components/schemas/Core_QuarantineStatus"
+            },
+            "example": "Quarantined"
           },
           {
             "name": "kind",
@@ -9639,6 +9893,227 @@
         ]
       }
     },
+    "/v1/domains/{domainId}/compliance/travel-rule/providers/{provider}/relationships": {
+      "post": {
+        "tags": ["Compliance"],
+        "summary": "Create a relationship with the travel rule provider",
+        "description": "Pass-through proxy API to create a relationship with the travel rule provider (e.g., Notabene)",
+        "operationId": "CreateRelationship",
+        "parameters": [
+          {
+            "name": "domainId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "provider",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "enum": ["NOTABENE"],
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Compliance_CreateRelationshipRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Relationship created successfully"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Compliance_ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Compliance_ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Compliance_ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Domain not found",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Compliance_ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Compliance_ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "httpAuth": []
+          }
+        ]
+      },
+      "get": {
+        "tags": ["Compliance"],
+        "summary": "List all relationships registered with the travel rule provider",
+        "description": "Pass-through proxy API to list all relationships from the travel rule provider (e.g., Notabene)",
+        "operationId": "ListRelationships",
+        "parameters": [
+          {
+            "name": "domainId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "provider",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "enum": ["NOTABENE"],
+              "type": "string"
+            }
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "description": "Filter by 'from' DID (Decentralized Identifier)",
+            "schema": {
+              "pattern": "^did:[a-z0-9]+:.+$",
+              "type": "string",
+              "format": "did"
+            }
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "description": "Filter by 'to' DID (Decentralized Identifier)",
+            "schema": {
+              "pattern": "^did:[a-z0-9]+:.+$",
+              "type": "string",
+              "format": "did"
+            }
+          },
+          {
+            "name": "custodian",
+            "in": "query",
+            "description": "Filter by custodian DID (Decentralized Identifier)",
+            "schema": {
+              "pattern": "^did:[a-z0-9]+:.+$",
+              "type": "string",
+              "format": "did"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Relationships retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Compliance_RelationshipList"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Compliance_ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Compliance_ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Compliance_ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Domain not found",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Compliance_ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Compliance_ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "httpAuth": []
+          }
+        ]
+      }
+    },
     "/v1/domains/{domainId}/channels": {
       "get": {
         "tags": ["Event Distribution Service"],
@@ -10982,43 +11457,6 @@
           }
         }
       },
-      "Core_ApiBatchInnerTransactionMeta": {
-        "required": ["index", "account", "operationType", "role"],
-        "type": "object",
-        "properties": {
-          "index": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "account": {
-            "type": "string"
-          },
-          "operationType": {
-            "type": "string"
-          },
-          "role": {
-            "type": "string"
-          }
-        }
-      },
-      "Core_ApiBatchSigningData": {
-        "required": ["signingPayloadHex", "signingPayloadHashHex", "innerTransactions"],
-        "type": "object",
-        "properties": {
-          "signingPayloadHex": {
-            "type": "string"
-          },
-          "signingPayloadHashHex": {
-            "type": "string"
-          },
-          "innerTransactions": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Core_ApiBatchInnerTransactionMeta"
-            }
-          }
-        }
-      },
       "Core_ApiBroadcastingTransactionProcessingHint": {
         "enum": [
           "CurrentlyFeesTooSmall",
@@ -11436,7 +11874,11 @@
             "format": "uuid"
           },
           "quarantined": {
-            "type": "boolean"
+            "type": "boolean",
+            "deprecated": true
+          },
+          "quarantineStatus": {
+            "$ref": "#/components/schemas/Core_QuarantineStatus"
           },
           "senders": {
             "type": "array",
@@ -11880,45 +12322,6 @@
           }
         }
       },
-      "Core_BatchInnerTransaction": {
-        "required": ["operation", "account"],
-        "type": "object",
-        "properties": {
-          "operation": {
-            "$ref": "#/components/schemas/Core_XrplOperation"
-          },
-          "account": {
-            "type": "string"
-          },
-          "sequence": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "ticketSequence": {
-            "type": "integer",
-            "format": "int64"
-          }
-        }
-      },
-      "Core_BatchSigner": {
-        "required": ["account", "signingPubKey", "txnSignature"],
-        "type": "object",
-        "properties": {
-          "account": {
-            "type": "string"
-          },
-          "signingPubKey": {
-            "pattern": "^[A-Fa-f0-9]*$",
-            "type": "string",
-            "description": "Hex encoded string."
-          },
-          "txnSignature": {
-            "pattern": "^[A-Fa-f0-9]*$",
-            "type": "string",
-            "description": "Hex encoded string."
-          }
-        }
-      },
       "Core_BitcoinFee": {
         "required": ["satoshiPerVbyte"],
         "type": "object",
@@ -12282,6 +12685,72 @@
         "properties": {
           "type": {
             "enum": ["Native"],
+            "type": "string"
+          }
+        }
+      },
+      "Core_ComplianceConfiguration": {
+        "required": ["accountId", "domainId", "skipQuarantineFrom", "metadata"],
+        "type": "object",
+        "properties": {
+          "accountId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "domainId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "skipQuarantineFrom": {
+            "$ref": "#/components/schemas/Core_SkipQuarantineScope"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/Core_EntityMetadata"
+          }
+        }
+      },
+      "Core_ComplianceConfigurationUpdated": {
+        "required": ["accountReference", "skipQuarantineFrom", "revision", "type"],
+        "type": "object",
+        "properties": {
+          "accountReference": {
+            "$ref": "#/components/schemas/Core_AccountReference"
+          },
+          "skipQuarantineFrom": {
+            "$ref": "#/components/schemas/Core_SkipQuarantineScope"
+          },
+          "revision": {
+            "minimum": 1,
+            "type": "integer",
+            "format": "int64"
+          },
+          "modifiedBy": {
+            "$ref": "#/components/schemas/Core_UserReference"
+          },
+          "type": {
+            "enum": ["ComplianceConfigurationUpdated"],
+            "type": "string"
+          }
+        }
+      },
+      "Core_ComplianceConfigurationsCollection": {
+        "required": ["items", "count"],
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Core_ComplianceConfiguration"
+            }
+          },
+          "count": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "currentStartingAfter": {
+            "type": "string"
+          },
+          "nextStartingAfter": {
             "type": "string"
           }
         }
@@ -13539,6 +14008,9 @@
             "$ref": "#/components/schemas/Core_BalancesUpdated"
           },
           {
+            "$ref": "#/components/schemas/Core_ComplianceConfigurationUpdated"
+          },
+          {
             "$ref": "#/components/schemas/Core_DomainCreated"
           },
           {
@@ -13584,6 +14056,12 @@
             "$ref": "#/components/schemas/Core_PolicyUpdated"
           },
           {
+            "$ref": "#/components/schemas/Core_QuarantineApplied"
+          },
+          {
+            "$ref": "#/components/schemas/Core_QuarantineSkipped"
+          },
+          {
             "$ref": "#/components/schemas/Core_SystemPropertySet"
           },
           {
@@ -13620,6 +14098,12 @@
             "$ref": "#/components/schemas/Core_VaultCreated"
           },
           {
+            "$ref": "#/components/schemas/Core_VaultKeyMaterialRewrapCompleted"
+          },
+          {
+            "$ref": "#/components/schemas/Core_VaultKeyMaterialRewrapFailed"
+          },
+          {
             "$ref": "#/components/schemas/Core_VaultUpdated"
           }
         ],
@@ -13632,6 +14116,7 @@
             "BackupCreated": "#/components/schemas/Core_BackupCreated",
             "BackupUpdated": "#/components/schemas/Core_BackupUpdated",
             "BalancesUpdated": "#/components/schemas/Core_BalancesUpdated",
+            "ComplianceConfigurationUpdated": "#/components/schemas/Core_ComplianceConfigurationUpdated",
             "DomainCreated": "#/components/schemas/Core_DomainCreated",
             "DomainUpdated": "#/components/schemas/Core_DomainUpdated",
             "EndpointCreated": "#/components/schemas/Core_EndpointCreated",
@@ -13647,6 +14132,8 @@
             "ManifestUpdated": "#/components/schemas/Core_ManifestUpdated",
             "PolicyCreated": "#/components/schemas/Core_PolicyCreated",
             "PolicyUpdated": "#/components/schemas/Core_PolicyUpdated",
+            "QuarantineApplied": "#/components/schemas/Core_QuarantineApplied",
+            "QuarantineSkipped": "#/components/schemas/Core_QuarantineSkipped",
             "SystemPropertySet": "#/components/schemas/Core_SystemPropertySet",
             "TickerCreated": "#/components/schemas/Core_TickerCreated",
             "TickerUpdated": "#/components/schemas/Core_TickerUpdated",
@@ -13659,6 +14146,8 @@
             "UserCreated": "#/components/schemas/Core_UserCreated",
             "UserUpdated": "#/components/schemas/Core_UserUpdated",
             "VaultCreated": "#/components/schemas/Core_VaultCreated",
+            "VaultKeyMaterialRewrapCompleted": "#/components/schemas/Core_VaultKeyMaterialRewrapCompleted",
+            "VaultKeyMaterialRewrapFailed": "#/components/schemas/Core_VaultKeyMaterialRewrapFailed",
             "VaultUpdated": "#/components/schemas/Core_VaultUpdated"
           }
         }
@@ -14042,6 +14531,9 @@
             "$ref": "#/components/schemas/Core_IntentDryRunResponse_v0_ReleaseQuarantinedTransfers"
           },
           {
+            "$ref": "#/components/schemas/Core_IntentDryRunResponse_v0_RewrapVaultKeyMaterial"
+          },
+          {
             "$ref": "#/components/schemas/Core_IntentDryRunResponse_v0_SetSystemProperty"
           },
           {
@@ -14128,6 +14620,7 @@
             "v0_MigrateSilo3AccountBatch": "#/components/schemas/Core_IntentDryRunResponse_v0_MigrateSilo3AccountBatch",
             "v0_NotarizeData": "#/components/schemas/Core_IntentDryRunResponse_v0_NotarizeData",
             "v0_ReleaseQuarantinedTransfers": "#/components/schemas/Core_IntentDryRunResponse_v0_ReleaseQuarantinedTransfers",
+            "v0_RewrapVaultKeyMaterial": "#/components/schemas/Core_IntentDryRunResponse_v0_RewrapVaultKeyMaterial",
             "v0_SetSystemProperty": "#/components/schemas/Core_IntentDryRunResponse_v0_SetSystemProperty",
             "v0_SignManifest": "#/components/schemas/Core_IntentDryRunResponse_v0_SignManifest",
             "v0_UnlockAccount": "#/components/schemas/Core_IntentDryRunResponse_v0_UnlockAccount",
@@ -14688,6 +15181,26 @@
           }
         }
       },
+      "Core_IntentDryRunResponse_v0_RewrapVaultKeyMaterial": {
+        "required": ["success", "type"],
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "errors": {
+            "minItems": 1,
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "type": {
+            "enum": ["v0_RewrapVaultKeyMaterial"],
+            "type": "string"
+          }
+        }
+      },
       "Core_IntentDryRunResponse_v0_SetSystemProperty": {
         "required": ["success", "type"],
         "type": "object",
@@ -15206,6 +15719,7 @@
           "v0_UpdateVault",
           "v0_UnlockVault",
           "v0_LockVault",
+          "v0_RewrapVaultKeyMaterial",
           "v0_UnlockTicker",
           "v0_LockTicker",
           "v0_CreateEndpoint",
@@ -15978,6 +16492,9 @@
             "$ref": "#/components/schemas/Core_ManifestProcessingDetails_Completed"
           },
           {
+            "$ref": "#/components/schemas/Core_ManifestProcessingDetails_Failed"
+          },
+          {
             "$ref": "#/components/schemas/Core_ManifestProcessingDetails_Pending"
           },
           {
@@ -15988,6 +16505,7 @@
           "propertyName": "type",
           "mapping": {
             "Completed": "#/components/schemas/Core_ManifestProcessingDetails_Completed",
+            "Failed": "#/components/schemas/Core_ManifestProcessingDetails_Failed",
             "Pending": "#/components/schemas/Core_ManifestProcessingDetails_Pending",
             "Preparing": "#/components/schemas/Core_ManifestProcessingDetails_Preparing"
           }
@@ -15999,6 +16517,16 @@
         "properties": {
           "type": {
             "enum": ["Completed"],
+            "type": "string"
+          }
+        }
+      },
+      "Core_ManifestProcessingDetails_Failed": {
+        "required": ["type"],
+        "type": "object",
+        "properties": {
+          "type": {
+            "enum": ["Failed"],
             "type": "string"
           }
         }
@@ -16024,7 +16552,7 @@
         }
       },
       "Core_ManifestProcessingStatus": {
-        "enum": ["Pending", "Preparing", "Completed"],
+        "enum": ["Pending", "Preparing", "Completed", "Failed"],
         "type": "string"
       },
       "Core_ManifestUpdated": {
@@ -16787,6 +17315,9 @@
             "$ref": "#/components/schemas/Core_v0_ReleaseQuarantinedTransfers"
           },
           {
+            "$ref": "#/components/schemas/Core_v0_RewrapVaultKeyMaterial"
+          },
+          {
             "$ref": "#/components/schemas/Core_v0_SetSystemProperty"
           },
           {
@@ -16873,6 +17404,7 @@
             "v0_MigrateSilo3AccountBatch": "#/components/schemas/Core_v0_MigrateSilo3AccountBatch",
             "v0_NotarizeData": "#/components/schemas/Core_v0_NotarizeData",
             "v0_ReleaseQuarantinedTransfers": "#/components/schemas/Core_v0_ReleaseQuarantinedTransfers",
+            "v0_RewrapVaultKeyMaterial": "#/components/schemas/Core_v0_RewrapVaultKeyMaterial",
             "v0_SetSystemProperty": "#/components/schemas/Core_v0_SetSystemProperty",
             "v0_SignManifest": "#/components/schemas/Core_v0_SignManifest",
             "v0_UnlockAccount": "#/components/schemas/Core_v0_UnlockAccount",
@@ -16928,6 +17460,38 @@
             "type": "string"
           }
         }
+      },
+      "Core_QuarantineApplied": {
+        "required": ["transferId", "type"],
+        "type": "object",
+        "properties": {
+          "transferId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "type": {
+            "enum": ["QuarantineApplied"],
+            "type": "string"
+          }
+        }
+      },
+      "Core_QuarantineSkipped": {
+        "required": ["transferId", "type"],
+        "type": "object",
+        "properties": {
+          "transferId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "type": {
+            "enum": ["QuarantineSkipped"],
+            "type": "string"
+          }
+        }
+      },
+      "Core_QuarantineStatus": {
+        "enum": ["Quarantined", "Released", "Skipped"],
+        "type": "string"
       },
       "Core_ReadAccess": {
         "required": [
@@ -17379,6 +17943,10 @@
             "type": "string"
           }
         }
+      },
+      "Core_SkipQuarantineScope": {
+        "enum": ["None", "Domain", "Instance"],
+        "type": "string"
       },
       "Core_SolanaFeeStrategy": {
         "oneOf": [
@@ -19695,9 +20263,6 @@
             "type": "string",
             "description": "This field is a large integer that can be positive or zero. It is represented as a string because it may contain value that cannot be expressed with JSON number without a loss of precision."
           },
-          "batchSigningData": {
-            "$ref": "#/components/schemas/Core_ApiBatchSigningData"
-          },
           "type": {
             "enum": ["XRPL"],
             "type": "string"
@@ -21045,6 +21610,20 @@
           }
         }
       },
+      "Core_UpsertComplianceConfigurationRequest": {
+        "required": ["skipQuarantineFrom", "revision"],
+        "type": "object",
+        "properties": {
+          "skipQuarantineFrom": {
+            "$ref": "#/components/schemas/Core_SkipQuarantineScope"
+          },
+          "revision": {
+            "minimum": 1,
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
       "Core_User": {
         "required": ["id", "domainId", "alias", "publicKey", "roles", "lock", "metadata"],
         "type": "object",
@@ -21186,6 +21765,9 @@
             "$ref": "#/components/schemas/Core_v0_ReleaseQuarantinedTransfers"
           },
           {
+            "$ref": "#/components/schemas/Core_v0_RewrapVaultKeyMaterial"
+          },
+          {
             "$ref": "#/components/schemas/Core_v0_SetSystemProperty"
           },
           {
@@ -21272,6 +21854,7 @@
             "v0_MigrateSilo3AccountBatch": "#/components/schemas/Core_v0_MigrateSilo3AccountBatch",
             "v0_NotarizeData": "#/components/schemas/Core_v0_NotarizeData",
             "v0_ReleaseQuarantinedTransfers": "#/components/schemas/Core_v0_ReleaseQuarantinedTransfers",
+            "v0_RewrapVaultKeyMaterial": "#/components/schemas/Core_v0_RewrapVaultKeyMaterial",
             "v0_SetSystemProperty": "#/components/schemas/Core_v0_SetSystemProperty",
             "v0_SignManifest": "#/components/schemas/Core_v0_SignManifest",
             "v0_UnlockAccount": "#/components/schemas/Core_v0_UnlockAccount",
@@ -21340,6 +21923,7 @@
           "UnsupportedAccountKeyStrategy",
           "VaultNotFound",
           "VaultLocked",
+          "VaultHasRandomKeyAccounts",
           "VaultNotReady",
           "InvalidDestination",
           "InvalidTransactionOrderState",
@@ -21700,6 +22284,34 @@
             "format": "base64"
           },
           "hash": {
+            "type": "string"
+          }
+        }
+      },
+      "Core_VaultKeyMaterialRewrapCompleted": {
+        "required": ["id", "type"],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "type": {
+            "enum": ["VaultKeyMaterialRewrapCompleted"],
+            "type": "string"
+          }
+        }
+      },
+      "Core_VaultKeyMaterialRewrapFailed": {
+        "required": ["id", "type"],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "type": {
+            "enum": ["VaultKeyMaterialRewrapFailed"],
             "type": "string"
           }
         }
@@ -22200,9 +22812,6 @@
             "$ref": "#/components/schemas/Core_XrplOperation_AccountSet"
           },
           {
-            "$ref": "#/components/schemas/Core_XrplOperation_Batch"
-          },
-          {
             "$ref": "#/components/schemas/Core_XrplOperation_Clawback"
           },
           {
@@ -22230,9 +22839,6 @@
             "$ref": "#/components/schemas/Core_XrplOperation_Payment"
           },
           {
-            "$ref": "#/components/schemas/Core_XrplOperation_TicketCreate"
-          },
-          {
             "$ref": "#/components/schemas/Core_XrplOperation_TrustSet"
           }
         ],
@@ -22240,7 +22846,6 @@
           "propertyName": "type",
           "mapping": {
             "AccountSet": "#/components/schemas/Core_XrplOperation_AccountSet",
-            "Batch": "#/components/schemas/Core_XrplOperation_Batch",
             "Clawback": "#/components/schemas/Core_XrplOperation_Clawback",
             "DepositPreauth": "#/components/schemas/Core_XrplOperation_DepositPreauth",
             "EscrowFinish": "#/components/schemas/Core_XrplOperation_EscrowFinish",
@@ -22250,7 +22855,6 @@
             "MPTokenIssuanceSet": "#/components/schemas/Core_XrplOperation_MPTokenIssuanceSet",
             "OfferCreate": "#/components/schemas/Core_XrplOperation_OfferCreate",
             "Payment": "#/components/schemas/Core_XrplOperation_Payment",
-            "TicketCreate": "#/components/schemas/Core_XrplOperation_TicketCreate",
             "TrustSet": "#/components/schemas/Core_XrplOperation_TrustSet"
           }
         }
@@ -22271,39 +22875,6 @@
           },
           "type": {
             "enum": ["AccountSet"],
-            "type": "string"
-          }
-        }
-      },
-      "Core_XrplOperation_Batch": {
-        "required": ["executionMode", "innerTransactions", "batchSigners", "type"],
-        "type": "object",
-        "properties": {
-          "executionMode": {
-            "$ref": "#/components/schemas/Core_Xrpl_BatchExecutionMode"
-          },
-          "innerTransactions": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Core_BatchInnerTransaction"
-            }
-          },
-          "ticketSequence": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "lastLedgerSequence": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "batchSigners": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Core_BatchSigner"
-            }
-          },
-          "type": {
-            "enum": ["Batch"],
             "type": "string"
           }
         }
@@ -22527,20 +23098,6 @@
           }
         }
       },
-      "Core_XrplOperation_TicketCreate": {
-        "required": ["ticketCount", "type"],
-        "type": "object",
-        "properties": {
-          "ticketCount": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "type": {
-            "enum": ["TicketCreate"],
-            "type": "string"
-          }
-        }
-      },
       "Core_XrplOperation_TrustSet": {
         "required": ["flags", "limitAmount", "type"],
         "type": "object",
@@ -22725,10 +23282,6 @@
             "description": "This field is a large integer that can be positive or zero. It is represented as a string because it may contain value that cannot be expressed with JSON number without a loss of precision."
           }
         }
-      },
-      "Core_Xrpl_BatchExecutionMode": {
-        "enum": ["AllOrNothing", "OnlyOne", "UntilFailure", "Independent"],
-        "type": "string"
       },
       "Core_Xrpl_LimitAmount": {
         "required": ["currency", "value"],
@@ -23621,6 +24174,28 @@
           },
           "type": {
             "enum": ["v0_ReleaseQuarantinedTransfers"],
+            "type": "string"
+          }
+        }
+      },
+      "Core_v0_RewrapVaultKeyMaterial": {
+        "required": ["vaultId", "customProperties", "type"],
+        "type": "object",
+        "properties": {
+          "vaultId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "description": {
+            "maxLength": 250,
+            "minLength": 0,
+            "type": "string"
+          },
+          "customProperties": {
+            "$ref": "#/components/schemas/Core_StringsMap"
+          },
+          "type": {
+            "enum": ["v0_RewrapVaultKeyMaterial"],
             "type": "string"
           }
         }
@@ -26728,6 +27303,132 @@
           }
         },
         "description": "Individual travel rule detail for a single request"
+      },
+      "Compliance_CreateRelationshipRequest": {
+        "required": ["to"],
+        "type": "object",
+        "properties": {
+          "from": {
+            "pattern": "^did:[a-z0-9]+:.+$",
+            "type": "string",
+            "description": "The DID of the source entity. Defaults to the entityDID from the domain credentials.",
+            "format": "did",
+            "example": "did:web:ripple.com:test:us"
+          },
+          "to": {
+            "pattern": "^did:[a-z0-9]+:.+$",
+            "type": "string",
+            "description": "The DID of the target entity.",
+            "format": "did",
+            "example": "did:web:example.com:test:counterparty"
+          }
+        },
+        "description": "Request to create a relationship with a travel rule provider"
+      },
+      "Compliance_RelationshipList": {
+        "type": "object",
+        "properties": {
+          "relationships": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Compliance_RelationshipWithProofs"
+            },
+            "description": "Array of relationship objects with ownership proofs"
+          }
+        },
+        "description": "List of relationships from the travel rule provider"
+      },
+      "Compliance_RelationshipWithProofs": {
+        "required": ["@id", "from", "to", "status"],
+        "type": "object",
+        "properties": {
+          "@id": {
+            "type": "string",
+            "description": "Unique identifier for the relationship",
+            "example": "urn:uuid:12345678-1234-1234-1234-123456789abc"
+          },
+          "from": {
+            "pattern": "^did:[a-z0-9]+:.+$",
+            "type": "string",
+            "description": "Decentralized Identifier (DID) of the source entity",
+            "format": "did",
+            "example": "did:web:ripple.com:test:us"
+          },
+          "to": {
+            "pattern": "^did:[a-z0-9]+:.+$",
+            "type": "string",
+            "description": "Decentralized Identifier (DID) of the target entity",
+            "format": "did",
+            "example": "did:web:example.com:test:counterparty"
+          },
+          "custodian": {
+            "pattern": "^did:[a-z0-9]+:.+$",
+            "type": "string",
+            "description": "Decentralized Identifier (DID) of the custodian entity (optional)",
+            "format": "did",
+            "example": "did:web:custodian.com:test:vault"
+          },
+          "status": {
+            "enum": ["UNCONFIRMED", "CONFIRMED", "REJECTED"],
+            "type": "string",
+            "description": "Current state of the relationship",
+            "example": "CONFIRMED"
+          },
+          "confirmedBy": {
+            "pattern": "^did:[a-z0-9]+:.+$",
+            "type": "string",
+            "description": "Decentralized Identifier (DID) of the entity that confirmed the relationship",
+            "format": "did",
+            "example": "did:web:example.com:test:counterparty"
+          },
+          "proofs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Compliance_OwnershipProof"
+            },
+            "description": "Ownership proofs associated with this relationship"
+          }
+        },
+        "description": "A relationship between two entities with ownership proofs"
+      },
+      "Compliance_OwnershipProof": {
+        "required": ["address", "status"],
+        "type": "object",
+        "properties": {
+          "address": {
+            "type": "string",
+            "description": "The blockchain address being proven",
+            "example": "0x1234567890abcdef1234567890abcdef12345678"
+          },
+          "chain": {
+            "type": "string",
+            "description": "The blockchain network",
+            "example": "ethereum"
+          },
+          "status": {
+            "enum": ["PENDING", "CONFIRMED", "VERIFIED", "REJECTED"],
+            "type": "string",
+            "description": "Status of the ownership proof",
+            "example": "VERIFIED"
+          },
+          "signature": {
+            "type": "string",
+            "description": "Cryptographic signature proving ownership",
+            "example": "0xabcdef..."
+          },
+          "message": {
+            "type": "string",
+            "description": "The message that was signed",
+            "example": "I own this address"
+          },
+          "timestamp": {
+            "type": "string",
+            "description": "When the proof was created",
+            "format": "date-time",
+            "example": "2026-03-10T14:30:00.0000000+00:00"
+          }
+        },
+        "description": "Proof of ownership for an address or entity"
       },
       "EDS_ChannelCreate": {
         "required": ["createdBy", "id", "name", "supportedEventTypes", "type"],

--- a/src/constants/urls.ts
+++ b/src/constants/urls.ts
@@ -52,6 +52,9 @@ export const URLs = createURLs({
   accountBalancesRefresh: "/v1/domains/{domainId}/accounts/{accountId}/balances/refresh",
   accountManifests: "/v1/domains/{domainId}/accounts/{accountId}/manifests",
   accountManifest: "/v1/domains/{domainId}/accounts/{accountId}/manifests/{manifestId}",
+  accountComplianceConfiguration:
+    "/v1/domains/{domainId}/accounts/{accountId}/compliance-configuration",
+  complianceConfigurations: "/v1/domains/{domainId}/compliance-configurations",
 
   // Addresses
   addresses: "/v1/addresses",

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,14 +169,14 @@ export type {
 } from "./services/vaults/index.js"
 
 // xrpl types and functions
-export {
-  batchSignersToCustodyBatchSigners,
-  rawTransactionsToInnerTransactions,
-} from "./services/xrpl/index.js"
+// export {
+//   batchSignersToCustodyBatchSigners,
+//   rawTransactionsToInnerTransactions,
+// } from "./services/xrpl/index.js"
 export type {
   Core_XrplOperation,
   CustodyAccountSet,
-  CustodyBatch,
+  // CustodyBatch,
   CustodyClawback,
   CustodyDepositPreauth,
   CustodyMpTokenAuthorize,
@@ -185,7 +185,7 @@ export type {
   CustodyMpTokenIssuanceSet,
   CustodyOfferCreate,
   CustodyPayment,
-  CustodyTicketCreate,
+  // CustodyTicketCreate,
   CustodyTrustline,
   RawSignAndWaitOptions,
   RawSignAndWaitResult,

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,8 @@ export type {
   Core_ApiAccount,
   Core_ApiManifest,
   Core_BalancesCollection,
+  Core_ComplianceConfiguration,
+  Core_ComplianceConfigurationsCollection,
   Core_ManifestsCollection,
   ForceUpdateAccountBalancesPathParams,
   ForceUpdateAccountBalancesQueryParams,
@@ -65,9 +67,14 @@ export type {
   GetAddressesPathParams,
   GetAddressesQueryParams,
   GetAllDomainsAddressesQueryParams,
+  GetComplianceConfigurationPathParams,
   GetManifestPathParams,
   GetManifestsPathParams,
   GetManifestsQueryParams,
+  ListComplianceConfigurationsPathParams,
+  ListComplianceConfigurationsQueryParams,
+  UpsertComplianceConfigurationBody,
+  UpsertComplianceConfigurationPathParams,
 } from "./services/accounts/index.js"
 
 // transactions types

--- a/src/models/custody-types.ts
+++ b/src/models/custody-types.ts
@@ -259,6 +259,41 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  "/v1/domains/{domainId}/compliance-configurations": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** List compliance configurations for all accounts in a domain */
+    get: operations["listComplianceConfigurations"]
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/v1/domains/{domainId}/accounts/{accountId}/compliance-configuration": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Get compliance configuration for an account */
+    get: operations["getComplianceConfiguration"]
+    /** Create or update compliance configuration for an account */
+    put: operations["upsertComplianceConfiguration"]
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   "/v1/domains/{domainId}/accounts/{accountId}": {
     parameters: {
       query?: never
@@ -2385,6 +2420,30 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  "/v1/domains/{domainId}/compliance/travel-rule/providers/{provider}/relationships": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * List all relationships registered with the travel rule provider
+     * @description Pass-through proxy API to list all relationships from the travel rule provider (e.g., Notabene)
+     */
+    get: operations["ListRelationships"]
+    put?: never
+    /**
+     * Create a relationship with the travel rule provider
+     * @description Pass-through proxy API to create a relationship with the travel rule provider (e.g., Notabene)
+     */
+    post: operations["CreateRelationship"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   "/v1/domains/{domainId}/channels": {
     parameters: {
       query?: never
@@ -2948,18 +3007,6 @@ export interface components {
        */
       type: "VaultMPC"
     }
-    Core_ApiBatchInnerTransactionMeta: {
-      /** Format: int32 */
-      index: number
-      account: string
-      operationType: string
-      role: string
-    }
-    Core_ApiBatchSigningData: {
-      signingPayloadHex: string
-      signingPayloadHashHex: string
-      innerTransactions: components["schemas"]["Core_ApiBatchInnerTransactionMeta"][]
-    }
     /** @enum {string} */
     Core_ApiBroadcastingTransactionProcessingHint:
       | "CurrentlyFeesTooSmall"
@@ -3167,7 +3214,9 @@ export interface components {
       transactionId?: string
       /** Format: uuid */
       tickerId: string
+      /** @deprecated */
       quarantined: boolean
+      quarantineStatus?: components["schemas"]["Core_QuarantineStatus"]
       senders: components["schemas"]["Core_SenderTransferParty"][]
       recipient?: components["schemas"]["Core_RecipientTransferParty"]
       /** @description This field is a large integer that can be positive or zero. It is represented as a string because it may contain value that cannot be expressed with JSON number without a loss of precision. */
@@ -3355,21 +3404,6 @@ export interface components {
        */
       type: "BalancesUpdated"
     }
-    Core_BatchInnerTransaction: {
-      operation: components["schemas"]["Core_XrplOperation"]
-      account: string
-      /** Format: int64 */
-      sequence?: number
-      /** Format: int64 */
-      ticketSequence?: number
-    }
-    Core_BatchSigner: {
-      account: string
-      /** @description Hex encoded string. */
-      signingPubKey: string
-      /** @description Hex encoded string. */
-      txnSignature: string
-    }
     Core_BitcoinFee: {
       /** @description This field is a large decimal and represented as a string because it may contain value that cannot be expressed with JSON number without a loss of precision. */
       satoshiPerVbyte: string
@@ -3518,6 +3552,33 @@ export interface components {
        * @enum {string}
        */
       type: "Native"
+    }
+    Core_ComplianceConfiguration: {
+      /** Format: uuid */
+      accountId: string
+      /** Format: uuid */
+      domainId: string
+      skipQuarantineFrom: components["schemas"]["Core_SkipQuarantineScope"]
+      metadata: components["schemas"]["Core_EntityMetadata"]
+    }
+    Core_ComplianceConfigurationUpdated: {
+      accountReference: components["schemas"]["Core_AccountReference"]
+      skipQuarantineFrom: components["schemas"]["Core_SkipQuarantineScope"]
+      /** Format: int64 */
+      revision: number
+      modifiedBy?: components["schemas"]["Core_UserReference"]
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      type: "ComplianceConfigurationUpdated"
+    }
+    Core_ComplianceConfigurationsCollection: {
+      items: components["schemas"]["Core_ComplianceConfiguration"][]
+      /** Format: int32 */
+      count: number
+      currentStartingAfter?: string
+      nextStartingAfter?: string
     }
     Core_ContractParameters: components["schemas"]["Core_ContractParameters_Raw"]
     Core_ContractParameters_Raw: {
@@ -3984,6 +4045,7 @@ export interface components {
       | components["schemas"]["Core_BackupCreated"]
       | components["schemas"]["Core_BackupUpdated"]
       | components["schemas"]["Core_BalancesUpdated"]
+      | components["schemas"]["Core_ComplianceConfigurationUpdated"]
       | components["schemas"]["Core_DomainCreated"]
       | components["schemas"]["Core_DomainUpdated"]
       | components["schemas"]["Core_EndpointCreated"]
@@ -3999,6 +4061,8 @@ export interface components {
       | components["schemas"]["Core_ManifestUpdated"]
       | components["schemas"]["Core_PolicyCreated"]
       | components["schemas"]["Core_PolicyUpdated"]
+      | components["schemas"]["Core_QuarantineApplied"]
+      | components["schemas"]["Core_QuarantineSkipped"]
       | components["schemas"]["Core_SystemPropertySet"]
       | components["schemas"]["Core_TickerCreated"]
       | components["schemas"]["Core_TickerUpdated"]
@@ -4011,6 +4075,8 @@ export interface components {
       | components["schemas"]["Core_UserCreated"]
       | components["schemas"]["Core_UserUpdated"]
       | components["schemas"]["Core_VaultCreated"]
+      | components["schemas"]["Core_VaultKeyMaterialRewrapCompleted"]
+      | components["schemas"]["Core_VaultKeyMaterialRewrapFailed"]
       | components["schemas"]["Core_VaultUpdated"]
     Core_HederaFeeStrategy: components["schemas"]["Core_HederaFeeStrategy_Priority"]
     Core_HederaFeeStrategy_Priority: {
@@ -4164,6 +4230,7 @@ export interface components {
       | components["schemas"]["Core_IntentDryRunResponse_v0_MigrateSilo3AccountBatch"]
       | components["schemas"]["Core_IntentDryRunResponse_v0_NotarizeData"]
       | components["schemas"]["Core_IntentDryRunResponse_v0_ReleaseQuarantinedTransfers"]
+      | components["schemas"]["Core_IntentDryRunResponse_v0_RewrapVaultKeyMaterial"]
       | components["schemas"]["Core_IntentDryRunResponse_v0_SetSystemProperty"]
       | components["schemas"]["Core_IntentDryRunResponse_v0_SignManifest"]
       | components["schemas"]["Core_IntentDryRunResponse_v0_UnlockAccount"]
@@ -4423,6 +4490,15 @@ export interface components {
        */
       type: "v0_ReleaseQuarantinedTransfers"
     }
+    Core_IntentDryRunResponse_v0_RewrapVaultKeyMaterial: {
+      success: boolean
+      errors?: string[]
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      type: "v0_RewrapVaultKeyMaterial"
+    }
     Core_IntentDryRunResponse_v0_SetSystemProperty: {
       success: boolean
       errors?: string[]
@@ -4668,6 +4744,7 @@ export interface components {
       | "v0_UpdateVault"
       | "v0_UnlockVault"
       | "v0_LockVault"
+      | "v0_RewrapVaultKeyMaterial"
       | "v0_UnlockTicker"
       | "v0_LockTicker"
       | "v0_CreateEndpoint"
@@ -4981,6 +5058,7 @@ export interface components {
     }
     Core_ManifestProcessingDetails:
       | components["schemas"]["Core_ManifestProcessingDetails_Completed"]
+      | components["schemas"]["Core_ManifestProcessingDetails_Failed"]
       | components["schemas"]["Core_ManifestProcessingDetails_Pending"]
       | components["schemas"]["Core_ManifestProcessingDetails_Preparing"]
     Core_ManifestProcessingDetails_Completed: {
@@ -4989,6 +5067,13 @@ export interface components {
        * @enum {string}
        */
       type: "Completed"
+    }
+    Core_ManifestProcessingDetails_Failed: {
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      type: "Failed"
     }
     Core_ManifestProcessingDetails_Pending: {
       /**
@@ -5005,7 +5090,7 @@ export interface components {
       type: "Preparing"
     }
     /** @enum {string} */
-    Core_ManifestProcessingStatus: "Pending" | "Preparing" | "Completed"
+    Core_ManifestProcessingStatus: "Pending" | "Preparing" | "Completed" | "Failed"
     Core_ManifestUpdated: {
       /** Format: uuid */
       id: string
@@ -5306,6 +5391,7 @@ export interface components {
       | components["schemas"]["Core_v0_MigrateSilo3AccountBatch"]
       | components["schemas"]["Core_v0_NotarizeData"]
       | components["schemas"]["Core_v0_ReleaseQuarantinedTransfers"]
+      | components["schemas"]["Core_v0_RewrapVaultKeyMaterial"]
       | components["schemas"]["Core_v0_SetSystemProperty"]
       | components["schemas"]["Core_v0_SignManifest"]
       | components["schemas"]["Core_v0_UnlockAccount"]
@@ -5340,6 +5426,26 @@ export interface components {
        */
       type: "v0_CreateTransactionOrder"
     }
+    Core_QuarantineApplied: {
+      /** Format: uuid */
+      transferId: string
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      type: "QuarantineApplied"
+    }
+    Core_QuarantineSkipped: {
+      /** Format: uuid */
+      transferId: string
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      type: "QuarantineSkipped"
+    }
+    /** @enum {string} */
+    Core_QuarantineStatus: "Quarantined" | "Released" | "Skipped"
     Core_ReadAccess: {
       domains: string[]
       users: string[]
@@ -5482,6 +5588,8 @@ export interface components {
        */
       type: "Address"
     }
+    /** @enum {string} */
+    Core_SkipQuarantineScope: "None" | "Domain" | "Instance"
     Core_SolanaFeeStrategy: components["schemas"]["Core_SolanaFeeStrategy_Priority"]
     Core_SolanaFeeStrategy_Priority: {
       priority: components["schemas"]["Core_FeePriority"]
@@ -6510,7 +6618,6 @@ export interface components {
       minimumCostInDrops: string
       /** @description This field is a large integer that can be positive or zero. It is represented as a string because it may contain value that cannot be expressed with JSON number without a loss of precision. */
       fee: string
-      batchSigningData?: components["schemas"]["Core_ApiBatchSigningData"]
       /**
        * @description discriminator enum property added by openapi-typescript
        * @enum {string}
@@ -7103,6 +7210,11 @@ export interface components {
       currentStartingAfter?: string
       nextStartingAfter?: string
     }
+    Core_UpsertComplianceConfigurationRequest: {
+      skipQuarantineFrom: components["schemas"]["Core_SkipQuarantineScope"]
+      /** Format: int64 */
+      revision: number
+    }
     Core_User: {
       /** Format: uuid */
       id: string
@@ -7153,6 +7265,7 @@ export interface components {
       | components["schemas"]["Core_v0_MigrateSilo3AccountBatch"]
       | components["schemas"]["Core_v0_NotarizeData"]
       | components["schemas"]["Core_v0_ReleaseQuarantinedTransfers"]
+      | components["schemas"]["Core_v0_RewrapVaultKeyMaterial"]
       | components["schemas"]["Core_v0_SetSystemProperty"]
       | components["schemas"]["Core_v0_SignManifest"]
       | components["schemas"]["Core_v0_UnlockAccount"]
@@ -7218,6 +7331,7 @@ export interface components {
       | "UnsupportedAccountKeyStrategy"
       | "VaultNotFound"
       | "VaultLocked"
+      | "VaultHasRandomKeyAccounts"
       | "VaultNotReady"
       | "InvalidDestination"
       | "InvalidTransactionOrderState"
@@ -7388,6 +7502,24 @@ export interface components {
       /** Format: base64 */
       encryptedSeed: string
       hash: string
+    }
+    Core_VaultKeyMaterialRewrapCompleted: {
+      /** Format: uuid */
+      id: string
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      type: "VaultKeyMaterialRewrapCompleted"
+    }
+    Core_VaultKeyMaterialRewrapFailed: {
+      /** Format: uuid */
+      id: string
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      type: "VaultKeyMaterialRewrapFailed"
     }
     /** @enum {string} */
     Core_VaultKeyStrategy: "VaultHard" | "VaultSoft" | "Random"
@@ -7615,7 +7747,6 @@ export interface components {
     Core_XrplOnLedgerTokenData: components["schemas"]["Core_MultiPurposeToken"]
     Core_XrplOperation:
       | components["schemas"]["Core_XrplOperation_AccountSet"]
-      | components["schemas"]["Core_XrplOperation_Batch"]
       | components["schemas"]["Core_XrplOperation_Clawback"]
       | components["schemas"]["Core_XrplOperation_DepositPreauth"]
       | components["schemas"]["Core_XrplOperation_EscrowFinish"]
@@ -7625,7 +7756,6 @@ export interface components {
       | components["schemas"]["Core_XrplOperation_MPTokenIssuanceSet"]
       | components["schemas"]["Core_XrplOperation_OfferCreate"]
       | components["schemas"]["Core_XrplOperation_Payment"]
-      | components["schemas"]["Core_XrplOperation_TicketCreate"]
       | components["schemas"]["Core_XrplOperation_TrustSet"]
     Core_XrplOperation_AccountSet: {
       setFlag?: components["schemas"]["Core_Xrpl_AccountSetFlag"]
@@ -7637,20 +7767,6 @@ export interface components {
        * @enum {string}
        */
       type: "AccountSet"
-    }
-    Core_XrplOperation_Batch: {
-      executionMode: components["schemas"]["Core_Xrpl_BatchExecutionMode"]
-      innerTransactions: components["schemas"]["Core_BatchInnerTransaction"][]
-      /** Format: int64 */
-      ticketSequence?: number
-      /** Format: int64 */
-      lastLedgerSequence?: number
-      batchSigners: components["schemas"]["Core_BatchSigner"][]
-      /**
-       * @description discriminator enum property added by openapi-typescript
-       * @enum {string}
-       */
-      type: "Batch"
     }
     Core_XrplOperation_Clawback: {
       currency: components["schemas"]["Core_XrplClawbackCurrency"]
@@ -7756,15 +7872,6 @@ export interface components {
        */
       type: "Payment"
     }
-    Core_XrplOperation_TicketCreate: {
-      /** Format: int32 */
-      ticketCount: number
-      /**
-       * @description discriminator enum property added by openapi-typescript
-       * @enum {string}
-       */
-      type: "TicketCreate"
-    }
     Core_XrplOperation_TrustSet: {
       flags: components["schemas"]["Core_Xrpl_TrustSetFlag"][]
       limitAmount: components["schemas"]["Core_Xrpl_LimitAmount"]
@@ -7850,8 +7957,6 @@ export interface components {
       /** @description This field is a large integer that can be positive or zero. It is represented as a string because it may contain value that cannot be expressed with JSON number without a loss of precision. */
       amount: string
     }
-    /** @enum {string} */
-    Core_Xrpl_BatchExecutionMode: "AllOrNothing" | "OnlyOne" | "UntilFailure" | "Independent"
     Core_Xrpl_LimitAmount: {
       currency: components["schemas"]["Core_XrplIouCurrency"]
       /** @description This field is a large integer that can be positive or zero. It is represented as a string because it may contain value that cannot be expressed with JSON number without a loss of precision. */
@@ -8230,6 +8335,17 @@ export interface components {
        * @enum {string}
        */
       type: "v0_ReleaseQuarantinedTransfers"
+    }
+    Core_v0_RewrapVaultKeyMaterial: {
+      /** Format: uuid */
+      vaultId: string
+      description?: string
+      customProperties: components["schemas"]["Core_StringsMap"]
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      type: "v0_RewrapVaultKeyMaterial"
     }
     Core_v0_SetSystemProperty: {
       /** Format: int64 */
@@ -9485,6 +9601,101 @@ export interface components {
       direction?: "INCOMING" | "OUTGOING"
       transfer?: components["schemas"]["Compliance_Transfer"]
     }
+    /** @description Request to create a relationship with a travel rule provider */
+    Compliance_CreateRelationshipRequest: {
+      /**
+       * Format: did
+       * @description The DID of the source entity. Defaults to the entityDID from the domain credentials.
+       * @example did:web:ripple.com:test:us
+       */
+      from?: string
+      /**
+       * Format: did
+       * @description The DID of the target entity.
+       * @example did:web:example.com:test:counterparty
+       */
+      to: string
+    }
+    /** @description List of relationships from the travel rule provider */
+    Compliance_RelationshipList: {
+      /** @description Array of relationship objects with ownership proofs */
+      relationships?: components["schemas"]["Compliance_RelationshipWithProofs"][]
+    }
+    /** @description A relationship between two entities with ownership proofs */
+    Compliance_RelationshipWithProofs: {
+      /**
+       * @description Unique identifier for the relationship
+       * @example urn:uuid:12345678-1234-1234-1234-123456789abc
+       */
+      "@id": string
+      /**
+       * Format: did
+       * @description Decentralized Identifier (DID) of the source entity
+       * @example did:web:ripple.com:test:us
+       */
+      from: string
+      /**
+       * Format: did
+       * @description Decentralized Identifier (DID) of the target entity
+       * @example did:web:example.com:test:counterparty
+       */
+      to: string
+      /**
+       * Format: did
+       * @description Decentralized Identifier (DID) of the custodian entity (optional)
+       * @example did:web:custodian.com:test:vault
+       */
+      custodian?: string
+      /**
+       * @description Current state of the relationship
+       * @example CONFIRMED
+       * @enum {string}
+       */
+      status: "UNCONFIRMED" | "CONFIRMED" | "REJECTED"
+      /**
+       * Format: did
+       * @description Decentralized Identifier (DID) of the entity that confirmed the relationship
+       * @example did:web:example.com:test:counterparty
+       */
+      confirmedBy?: string
+      /** @description Ownership proofs associated with this relationship */
+      proofs?: components["schemas"]["Compliance_OwnershipProof"][]
+    }
+    /** @description Proof of ownership for an address or entity */
+    Compliance_OwnershipProof: {
+      /**
+       * @description The blockchain address being proven
+       * @example 0x1234567890abcdef1234567890abcdef12345678
+       */
+      address: string
+      /**
+       * @description The blockchain network
+       * @example ethereum
+       */
+      chain?: string
+      /**
+       * @description Status of the ownership proof
+       * @example VERIFIED
+       * @enum {string}
+       */
+      status: "PENDING" | "CONFIRMED" | "VERIFIED" | "REJECTED"
+      /**
+       * @description Cryptographic signature proving ownership
+       * @example 0xabcdef...
+       */
+      signature?: string
+      /**
+       * @description The message that was signed
+       * @example I own this address
+       */
+      message?: string
+      /**
+       * Format: date-time
+       * @description When the proof was created
+       * @example 2026-03-10T14:30:00.0000000+00:00
+       */
+      timestamp?: string
+    }
     EDS_ChannelCreate: {
       /** Format: uuid */
       id: string
@@ -10640,6 +10851,164 @@ export interface operations {
       }
     }
   }
+  listComplianceConfigurations: {
+    parameters: {
+      query?: {
+        /** @description The number of entities to return. */
+        limit?: number
+        /** @description Entity id used to the determine beginning of query results. */
+        startingAfter?: string
+      }
+      header?: never
+      path: {
+        /** @description Unique identifier for the domain. */
+        domainId: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["Core_ComplianceConfigurationsCollection"]
+        }
+      }
+      /** @description One of: Domain locked (DomainLockedError); Requester locked (RequesterLockedError) */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["Core_ErrorMessage"]
+        }
+      }
+      /** @description One of: Invalid JWT (InvalidJwtError); User not authorized (PermissionDeniedError) */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["Core_ErrorMessage"]
+        }
+      }
+      /** @description Entity or Domain not found (EntityNotFoundError) */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["Core_ErrorMessage"]
+        }
+      }
+    }
+  }
+  getComplianceConfiguration: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description Unique identifier for the domain. */
+        domainId: string
+        accountId: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["Core_ComplianceConfiguration"]
+        }
+      }
+      /** @description One of: Domain locked (DomainLockedError); Requester locked (RequesterLockedError) */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["Core_ErrorMessage"]
+        }
+      }
+      /** @description One of: Invalid JWT (InvalidJwtError); User not authorized (PermissionDeniedError) */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["Core_ErrorMessage"]
+        }
+      }
+      /** @description Entity or Domain not found (EntityNotFoundError) */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["Core_ErrorMessage"]
+        }
+      }
+    }
+  }
+  upsertComplianceConfiguration: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description Unique identifier for the domain. */
+        domainId: string
+        accountId: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["Core_UpsertComplianceConfigurationRequest"]
+      }
+    }
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["Core_ComplianceConfiguration"]
+        }
+      }
+      /** @description One of: Domain locked (DomainLockedError); Invalid request (InvalidRequestError); Requester locked (RequesterLockedError) */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["Core_ErrorMessage"]
+        }
+      }
+      /** @description One of: Invalid JWT (InvalidJwtError); User not authorized (PermissionDeniedError) */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["Core_ErrorMessage"]
+        }
+      }
+      /** @description Entity or Domain not found (EntityNotFoundError) */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["Core_ErrorMessage"]
+        }
+      }
+    }
+  }
   getAccount: {
     parameters: {
       query?: never
@@ -11186,7 +11555,7 @@ export interface operations {
   forceUpdateAccountBalances: {
     parameters: {
       query?: {
-        /** @description Updates only balances with the given ledger id. Reduces execution time. */
+        /** @description Updates only balances for native and validated tickers with the given ledger id. Non-validated token tickers are excluded. Reduces execution time. */
         ledgerId?: string
         /** @description Updates only balances with the given ticker id. Reduces execution time. */
         tickerId?: string
@@ -11617,10 +11986,16 @@ export interface operations {
          */
         tickerId?: string
         /**
-         * @description Return entities matching given quarantined status.
+         * @deprecated
+         * @description Deprecated: use quarantineStatus instead. Return entities matching given quarantined status.
          * @example true
          */
         quarantined?: boolean
+        /**
+         * @description Return entities matching given quarantine status. Values: Quarantined, Released, Skipped.
+         * @example Quarantined
+         */
+        quarantineStatus?: components["schemas"]["Core_QuarantineStatus"]
         /**
          * @description Return entities matching given kind.
          * @example Fee
@@ -14699,6 +15074,151 @@ export interface operations {
         }
       }
       /** @description Domain or Travel rule details not found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "*/*": components["schemas"]["Compliance_ErrorResponse"]
+        }
+      }
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "*/*": components["schemas"]["Compliance_ErrorResponse"]
+        }
+      }
+    }
+  }
+  ListRelationships: {
+    parameters: {
+      query?: {
+        /** @description Filter by 'from' DID (Decentralized Identifier) */
+        from?: string
+        /** @description Filter by 'to' DID (Decentralized Identifier) */
+        to?: string
+        /** @description Filter by custodian DID (Decentralized Identifier) */
+        custodian?: string
+      }
+      header?: never
+      path: {
+        domainId: string
+        provider: "NOTABENE"
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Relationships retrieved successfully */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "application/json": components["schemas"]["Compliance_RelationshipList"]
+        }
+      }
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "*/*": components["schemas"]["Compliance_ErrorResponse"]
+        }
+      }
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "*/*": components["schemas"]["Compliance_ErrorResponse"]
+        }
+      }
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "*/*": components["schemas"]["Compliance_ErrorResponse"]
+        }
+      }
+      /** @description Domain not found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "*/*": components["schemas"]["Compliance_ErrorResponse"]
+        }
+      }
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "*/*": components["schemas"]["Compliance_ErrorResponse"]
+        }
+      }
+    }
+  }
+  CreateRelationship: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        domainId: string
+        provider: "NOTABENE"
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["Compliance_CreateRelationshipRequest"]
+      }
+    }
+    responses: {
+      /** @description Relationship created successfully */
+      201: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "*/*": components["schemas"]["Compliance_ErrorResponse"]
+        }
+      }
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "*/*": components["schemas"]["Compliance_ErrorResponse"]
+        }
+      }
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "*/*": components["schemas"]["Compliance_ErrorResponse"]
+        }
+      }
+      /** @description Domain not found */
       404: {
         headers: {
           [name: string]: unknown

--- a/src/namespaces/accounts.ts
+++ b/src/namespaces/accounts.ts
@@ -118,8 +118,7 @@ export function createAccounts(t: TypedTransport) {
 
     getComplianceConfiguration: (
       params: GetComplianceConfigurationPathParams,
-    ): Promise<Core_ComplianceConfiguration> =>
-      t.get(URLs.accountComplianceConfiguration, params),
+    ): Promise<Core_ComplianceConfiguration> => t.get(URLs.accountComplianceConfiguration, params),
 
     upsertComplianceConfiguration: (
       params: UpsertComplianceConfigurationPathParams,

--- a/src/namespaces/accounts.ts
+++ b/src/namespaces/accounts.ts
@@ -9,6 +9,8 @@ import type {
   Core_ApiAccount,
   Core_ApiManifest,
   Core_BalancesCollection,
+  Core_ComplianceConfiguration,
+  Core_ComplianceConfigurationsCollection,
   Core_ManifestsCollection,
   ForceUpdateAccountBalancesPathParams,
   ForceUpdateAccountBalancesQueryParams,
@@ -25,9 +27,14 @@ import type {
   GetAddressesPathParams,
   GetAddressesQueryParams,
   GetAllDomainsAddressesQueryParams,
+  GetComplianceConfigurationPathParams,
   GetManifestPathParams,
   GetManifestsPathParams,
   GetManifestsQueryParams,
+  ListComplianceConfigurationsPathParams,
+  ListComplianceConfigurationsQueryParams,
+  UpsertComplianceConfigurationBody,
+  UpsertComplianceConfigurationPathParams,
 } from "../services/accounts/accounts.types.js"
 import type { TypedTransport } from "../transport/index.js"
 
@@ -102,6 +109,23 @@ export function createAccounts(t: TypedTransport) {
 
     getManifest: (params: GetManifestPathParams): Promise<Core_ApiManifest> =>
       t.get(URLs.accountManifest, params),
+
+    listComplianceConfigurations: (
+      params: ListComplianceConfigurationsPathParams,
+      query?: ListComplianceConfigurationsQueryParams,
+    ): Promise<Core_ComplianceConfigurationsCollection> =>
+      t.get(URLs.complianceConfigurations, params, query),
+
+    getComplianceConfiguration: (
+      params: GetComplianceConfigurationPathParams,
+    ): Promise<Core_ComplianceConfiguration> =>
+      t.get(URLs.accountComplianceConfiguration, params),
+
+    upsertComplianceConfiguration: (
+      params: UpsertComplianceConfigurationPathParams,
+      body: UpsertComplianceConfigurationBody,
+    ): Promise<Core_ComplianceConfiguration> =>
+      t.put(URLs.accountComplianceConfiguration, body, params),
 
     findByAddress: (address: string): Promise<AccountReference> => findByAddress(t, address),
   } as const

--- a/src/ripple-custody.ts
+++ b/src/ripple-custody.ts
@@ -1,4 +1,4 @@
-import type { Batch, SubmittableTransaction } from "xrpl"
+import type { SubmittableTransaction } from "xrpl"
 import {
   createAccounts,
   createDomains,
@@ -21,8 +21,6 @@ import {
   type Core_XrplOperation,
   type RawSignAndWaitOptions,
   type RawSignAndWaitResult,
-  type RawSignInnerBatchAndWaitResult,
-  type RawSignInnerBatchOptions,
   type XrplIntentOptions,
 } from "./services/xrpl/index.js"
 import { TypedTransport } from "./transport/index.js"
@@ -142,12 +140,12 @@ export class RippleCustody {
      * @param options - Optional configuration for the raw sign intent
      * @returns The proposed intent response
      */
-    rawSignInnerBatch: async (
-      batch: Batch,
-      signerAddress: string,
-      options?: RawSignInnerBatchOptions,
-    ): Promise<Core_IntentResponse> =>
-      this.xrplService.rawSignInnerBatch(batch, signerAddress, options),
+    // rawSignInnerBatch: async (
+    //   batch: Batch,
+    //   signerAddress: string,
+    //   options?: RawSignInnerBatchOptions,
+    // ): Promise<Core_IntentResponse> =>
+    //   this.xrplService.rawSignInnerBatch(batch, signerAddress, options),
 
     /**
      * Signs a Batch transaction envelope for a single inner account and waits
@@ -157,12 +155,12 @@ export class RippleCustody {
      * @param options - Optional configuration for the raw sign intent and polling
      * @returns The signature and signing public key in uppercase hex
      */
-    rawSignInnerBatchAndWait: async (
-      batch: Batch,
-      signerAddress: string,
-      options?: RawSignInnerBatchOptions,
-    ): Promise<RawSignInnerBatchAndWaitResult> =>
-      this.xrplService.rawSignInnerBatchAndWait(batch, signerAddress, options),
+    // rawSignInnerBatchAndWait: async (
+    //   batch: Batch,
+    //   signerAddress: string,
+    //   options?: RawSignInnerBatchOptions,
+    // ): Promise<RawSignInnerBatchAndWaitResult> =>
+    //   this.xrplService.rawSignInnerBatchAndWait(batch, signerAddress, options),
 
     /**
      * Get the compressed secp256k1 public key for an XRPL account.

--- a/src/services/accounts/accounts.types.ts
+++ b/src/services/accounts/accounts.types.ts
@@ -37,6 +37,19 @@ export type GetManifestsQueryParams = operations["getManifests"]["parameters"]["
 
 export type GetManifestPathParams = operations["getManifest"]["parameters"]["path"]
 
+export type ListComplianceConfigurationsPathParams =
+  operations["listComplianceConfigurations"]["parameters"]["path"]
+export type ListComplianceConfigurationsQueryParams =
+  operations["listComplianceConfigurations"]["parameters"]["query"]
+
+export type GetComplianceConfigurationPathParams =
+  operations["getComplianceConfiguration"]["parameters"]["path"]
+
+export type UpsertComplianceConfigurationPathParams =
+  operations["upsertComplianceConfiguration"]["parameters"]["path"]
+export type UpsertComplianceConfigurationBody =
+  operations["upsertComplianceConfiguration"]["requestBody"]["content"]["application/json"]
+
 // Response types
 
 export type Core_AccountsCollection =
@@ -62,6 +75,12 @@ export type Core_ManifestsCollection =
 
 export type Core_ApiManifest =
   operations["getManifest"]["responses"]["200"]["content"]["application/json"]
+
+export type Core_ComplianceConfigurationsCollection =
+  operations["listComplianceConfigurations"]["responses"]["200"]["content"]["application/json"]
+
+export type Core_ComplianceConfiguration =
+  operations["getComplianceConfiguration"]["responses"]["200"]["content"]["application/json"]
 
 /**
  * Account reference found by address lookup.

--- a/src/services/apis/api.service.ts
+++ b/src/services/apis/api.service.ts
@@ -196,4 +196,36 @@ export class ApiService {
       }
     }
   }
+
+  /**
+   * Makes a PUT request to the API.
+   * @param url - The endpoint URL.
+   * @param body - The request payload (sent as-is; no canonicalization or signing).
+   * @returns {Promise<T>} The response data.
+   * @throws {CustodyError} If the request fails with a typed error response.
+   */
+  public async put<T>(url: string, body: any, config?: AxiosRequestConfig): Promise<T> {
+    try {
+      const response = await this.apiClient.put<T>(url, body, config)
+      return response.data
+    } catch (error) {
+      if (axios.isAxiosError<Core_ErrorMessage>(error)) {
+        const errorData = error.response?.data
+        if (isObject(errorData)) {
+          throw new CustodyError(errorData, error.response?.status, error)
+        }
+        throw new CustodyError(
+          { reason: `PUT API request failed: ${error.message}` },
+          error.response?.status,
+          error,
+        )
+      } else {
+        throw new CustodyError(
+          { reason: error instanceof Error ? error.message : "Unknown error occurred" },
+          undefined,
+          error instanceof Error ? error : undefined,
+        )
+      }
+    }
+  }
 }

--- a/src/services/xrpl/index.ts
+++ b/src/services/xrpl/index.ts
@@ -1,7 +1,7 @@
-export {
-  batchSignersToCustodyBatchSigners,
-  rawTransactionsToInnerTransactions,
-} from "./xrpl.adapters.js"
+// export {
+//   batchSignersToCustodyBatchSigners,
+//   rawTransactionsToInnerTransactions,
+// } from "./xrpl.adapters.js"
 export { createHttpPorts } from "./xrpl.http-adapters.js"
 export type { XrplPorts } from "./xrpl.ports.js"
 export * from "./xrpl.service.js"

--- a/src/services/xrpl/xrpl.adapters.test.ts
+++ b/src/services/xrpl/xrpl.adapters.test.ts
@@ -1,3 +1,5 @@
+//TODO: restore adapter tests once batchSignersToCustodyBatchSigners and rawTransactionsToInnerTransactions are supported
+/*
 import { describe, expect, it } from "vitest"
 import type { Batch, BatchSigner } from "xrpl"
 import {
@@ -612,4 +614,11 @@ describe("rawTransactionsToInnerTransactions", () => {
       expect(result).not.toHaveProperty("sequence")
     })
   })
+})
+*/
+
+// Stub test so vitest does not fail on a file with no tests.
+import { describe, it } from "vitest"
+describe.skip("xrpl.adapters (disabled — batch support removed)", () => {
+  it("restore tests when batch helpers return", () => {})
 })

--- a/src/services/xrpl/xrpl.adapters.ts
+++ b/src/services/xrpl/xrpl.adapters.ts
@@ -1,7 +1,6 @@
 import {
   AccountSetAsfFlags,
   type Batch,
-  type BatchSigner,
   type IssuedCurrencyAmount,
   MPTokenAuthorizeFlags,
   MPTokenIssuanceCreateFlags,
@@ -9,13 +8,11 @@ import {
   OfferCreateFlags,
   TrustSetFlags,
 } from "xrpl"
-import { isString } from "../../helpers/index.js"
 import type {
   CustodyAccountSetFlag,
-  CustodyBatchSigner,
-  CustodyInnerTransaction,
+  // CustodyBatchSigner,
+  // CustodyInnerTransaction,
   CustodyMpTokenIssuanceCreate,
-  CustodyOperation,
 } from "./xrpl.types.js"
 
 type RawTx = Batch["RawTransactions"][number]["RawTransaction"]
@@ -138,155 +135,155 @@ const mpTokenIssuanceSetFlagsToStrings = (
   return result
 }
 
-const txToOperation = (tx: RawTx): CustodyOperation => {
-  switch (tx.TransactionType) {
-    case "Payment": {
-      const amount = tx.Amount
-      if (isString(amount)) {
-        // XRP drops
-        return {
-          type: "Payment",
-          destination: { type: "Address", address: tx.Destination },
-          amount,
-          ...(tx.DestinationTag !== undefined && { destinationTag: tx.DestinationTag }),
-        }
-      }
-      const isMPT = "mpt_issuance_id" in amount
-      return {
-        type: "Payment",
-        destination: { type: "Address", address: tx.Destination },
-        amount: amount.value,
-        ...(tx.DestinationTag !== undefined && { destinationTag: tx.DestinationTag }),
-        currency: isMPT
-          ? { type: "MultiPurposeToken" as const, issuanceId: amount.mpt_issuance_id }
-          : {
-              type: "Currency" as const,
-              code: (amount as IssuedCurrencyAmount).currency,
-              issuer: (amount as IssuedCurrencyAmount).issuer,
-            },
-      }
-    }
-    case "OfferCreate":
-      return {
-        type: "OfferCreate",
-        takerGets: amountToAssetQuantity(tx.TakerGets as IssuedCurrencyAmount | string),
-        takerPays: amountToAssetQuantity(tx.TakerPays as IssuedCurrencyAmount | string),
-        flags: offerCreateFlagsToStrings(tx.Flags),
-      }
-    case "TrustSet":
-      return {
-        type: "TrustSet",
-        limitAmount: {
-          currency: {
-            type: "Currency",
-            code: tx.LimitAmount.currency,
-            issuer: tx.LimitAmount.issuer,
-          },
-          value: tx.LimitAmount.value,
-        },
-        flags: trustSetFlagsToStrings(tx.Flags),
-      }
-    case "AccountSet":
-      return {
-        type: "AccountSet",
-        ...(tx.SetFlag !== undefined && { setFlag: accountSetAsfFlagToString(tx.SetFlag) }),
-        ...(tx.ClearFlag !== undefined && { clearFlag: accountSetAsfFlagToString(tx.ClearFlag) }),
-        ...(tx.TransferRate !== undefined && { transferRate: tx.TransferRate }),
-      }
-    case "TicketCreate":
-      return {
-        type: "TicketCreate",
-        ticketCount: tx.TicketCount,
-      }
-    case "Clawback": {
-      const amount = tx.Amount
-      // Clawback Amount can be either an IOU (IssuedCurrencyAmount) or an MPT amount,
-      // distinguished by the presence of `mpt_issuance_id`.
-      const isMPT = "mpt_issuance_id" in amount
-      return {
-        type: "Clawback",
-        currency: isMPT
-          ? { type: "MultiPurposeToken" as const, issuanceId: amount.mpt_issuance_id }
-          : {
-              type: "Currency" as const,
-              code: (amount as IssuedCurrencyAmount).currency,
-              issuer: (amount as IssuedCurrencyAmount).issuer,
-            },
-        holder: { type: "Address" as const, address: tx.Holder as string },
-        value: amount.value,
-      }
-    }
-    case "DepositPreauth":
-      return {
-        type: "DepositPreauth",
-        ...(tx.Authorize !== undefined && {
-          authorize: { type: "Address" as const, address: tx.Authorize },
-        }),
-        ...(tx.Unauthorize !== undefined && {
-          unauthorize: { type: "Address" as const, address: tx.Unauthorize },
-        }),
-      }
-    case "EscrowFinish":
-      return {
-        type: "EscrowFinish",
-        owner: { type: "Address" as const, address: tx.Owner },
-        offerSequence: Number(tx.OfferSequence),
-        ...(tx.Condition !== undefined && { condition: tx.Condition }),
-        ...(tx.Fulfillment !== undefined && { fulfillment: tx.Fulfillment }),
-        ...(tx.CredentialIDs !== undefined && { credentialIds: tx.CredentialIDs }),
-      }
-    case "MPTokenAuthorize":
-      return {
-        type: "MPTokenAuthorize",
-        tokenIdentifier: { type: "MPTokenIssuanceId" as const, issuanceId: tx.MPTokenIssuanceID },
-        flags: mpTokenAuthorizeFlagsToStrings(tx.Flags),
-        ...(tx.Holder !== undefined && {
-          holder: { type: "Address" as const, address: tx.Holder },
-        }),
-      }
-    case "MPTokenIssuanceCreate":
-      return {
-        type: "MPTokenIssuanceCreate",
-        flags: mpTokenIssuanceCreateFlagsToStrings(tx.Flags),
-        ...(tx.AssetScale !== undefined && { assetScale: tx.AssetScale }),
-        ...(tx.TransferFee !== undefined && { transferFee: tx.TransferFee }),
-        ...(tx.MaximumAmount !== undefined && { maximumAmount: tx.MaximumAmount }),
-        ...(tx.MPTokenMetadata !== undefined && {
-          metadata: { type: "HexEncodedMetadata" as const, value: tx.MPTokenMetadata },
-        }),
-      }
-    case "MPTokenIssuanceDestroy":
-      return {
-        type: "MPTokenIssuanceDestroy",
-        tokenIdentifier: { type: "MPTokenIssuanceId" as const, issuanceId: tx.MPTokenIssuanceID },
-      }
-    case "MPTokenIssuanceSet":
-      return {
-        type: "MPTokenIssuanceSet",
-        tokenIdentifier: { type: "MPTokenIssuanceId" as const, issuanceId: tx.MPTokenIssuanceID },
-        flags: mpTokenIssuanceSetFlagsToStrings(tx.Flags),
-        ...(tx.Holder !== undefined && {
-          holder: { type: "Address" as const, address: tx.Holder },
-        }),
-      }
-    default:
-      throw new Error(`Unsupported transaction type: ${tx.TransactionType}`)
-  }
-}
+// const txToOperation = (tx: RawTx): CustodyOperation => {
+//   switch (tx.TransactionType) {
+//     case "Payment": {
+//       const amount = tx.Amount
+//       if (isString(amount)) {
+//         // XRP drops
+//         return {
+//           type: "Payment",
+//           destination: { type: "Address", address: tx.Destination },
+//           amount,
+//           ...(tx.DestinationTag !== undefined && { destinationTag: tx.DestinationTag }),
+//         }
+//       }
+//       const isMPT = "mpt_issuance_id" in amount
+//       return {
+//         type: "Payment",
+//         destination: { type: "Address", address: tx.Destination },
+//         amount: amount.value,
+//         ...(tx.DestinationTag !== undefined && { destinationTag: tx.DestinationTag }),
+//         currency: isMPT
+//           ? { type: "MultiPurposeToken" as const, issuanceId: amount.mpt_issuance_id }
+//           : {
+//               type: "Currency" as const,
+//               code: (amount as IssuedCurrencyAmount).currency,
+//               issuer: (amount as IssuedCurrencyAmount).issuer,
+//             },
+//       }
+//     }
+//     case "OfferCreate":
+//       return {
+//         type: "OfferCreate",
+//         takerGets: amountToAssetQuantity(tx.TakerGets as IssuedCurrencyAmount | string),
+//         takerPays: amountToAssetQuantity(tx.TakerPays as IssuedCurrencyAmount | string),
+//         flags: offerCreateFlagsToStrings(tx.Flags),
+//       }
+//     case "TrustSet":
+//       return {
+//         type: "TrustSet",
+//         limitAmount: {
+//           currency: {
+//             type: "Currency",
+//             code: tx.LimitAmount.currency,
+//             issuer: tx.LimitAmount.issuer,
+//           },
+//           value: tx.LimitAmount.value,
+//         },
+//         flags: trustSetFlagsToStrings(tx.Flags),
+//       }
+//     case "AccountSet":
+//       return {
+//         type: "AccountSet",
+//         ...(tx.SetFlag !== undefined && { setFlag: accountSetAsfFlagToString(tx.SetFlag) }),
+//         ...(tx.ClearFlag !== undefined && { clearFlag: accountSetAsfFlagToString(tx.ClearFlag) }),
+//         ...(tx.TransferRate !== undefined && { transferRate: tx.TransferRate }),
+//       }
+//     case "TicketCreate":
+//       return {
+//         type: "TicketCreate",
+//         ticketCount: tx.TicketCount,
+//       }
+//     case "Clawback": {
+//       const amount = tx.Amount
+//       // Clawback Amount can be either an IOU (IssuedCurrencyAmount) or an MPT amount,
+//       // distinguished by the presence of `mpt_issuance_id`.
+//       const isMPT = "mpt_issuance_id" in amount
+//       return {
+//         type: "Clawback",
+//         currency: isMPT
+//           ? { type: "MultiPurposeToken" as const, issuanceId: amount.mpt_issuance_id }
+//           : {
+//               type: "Currency" as const,
+//               code: (amount as IssuedCurrencyAmount).currency,
+//               issuer: (amount as IssuedCurrencyAmount).issuer,
+//             },
+//         holder: { type: "Address" as const, address: tx.Holder as string },
+//         value: amount.value,
+//       }
+//     }
+//     case "DepositPreauth":
+//       return {
+//         type: "DepositPreauth",
+//         ...(tx.Authorize !== undefined && {
+//           authorize: { type: "Address" as const, address: tx.Authorize },
+//         }),
+//         ...(tx.Unauthorize !== undefined && {
+//           unauthorize: { type: "Address" as const, address: tx.Unauthorize },
+//         }),
+//       }
+//     case "EscrowFinish":
+//       return {
+//         type: "EscrowFinish",
+//         owner: { type: "Address" as const, address: tx.Owner },
+//         offerSequence: Number(tx.OfferSequence),
+//         ...(tx.Condition !== undefined && { condition: tx.Condition }),
+//         ...(tx.Fulfillment !== undefined && { fulfillment: tx.Fulfillment }),
+//         ...(tx.CredentialIDs !== undefined && { credentialIds: tx.CredentialIDs }),
+//       }
+//     case "MPTokenAuthorize":
+//       return {
+//         type: "MPTokenAuthorize",
+//         tokenIdentifier: { type: "MPTokenIssuanceId" as const, issuanceId: tx.MPTokenIssuanceID },
+//         flags: mpTokenAuthorizeFlagsToStrings(tx.Flags),
+//         ...(tx.Holder !== undefined && {
+//           holder: { type: "Address" as const, address: tx.Holder },
+//         }),
+//       }
+//     case "MPTokenIssuanceCreate":
+//       return {
+//         type: "MPTokenIssuanceCreate",
+//         flags: mpTokenIssuanceCreateFlagsToStrings(tx.Flags),
+//         ...(tx.AssetScale !== undefined && { assetScale: tx.AssetScale }),
+//         ...(tx.TransferFee !== undefined && { transferFee: tx.TransferFee }),
+//         ...(tx.MaximumAmount !== undefined && { maximumAmount: tx.MaximumAmount }),
+//         ...(tx.MPTokenMetadata !== undefined && {
+//           metadata: { type: "HexEncodedMetadata" as const, value: tx.MPTokenMetadata },
+//         }),
+//       }
+//     case "MPTokenIssuanceDestroy":
+//       return {
+//         type: "MPTokenIssuanceDestroy",
+//         tokenIdentifier: { type: "MPTokenIssuanceId" as const, issuanceId: tx.MPTokenIssuanceID },
+//       }
+//     case "MPTokenIssuanceSet":
+//       return {
+//         type: "MPTokenIssuanceSet",
+//         tokenIdentifier: { type: "MPTokenIssuanceId" as const, issuanceId: tx.MPTokenIssuanceID },
+//         flags: mpTokenIssuanceSetFlagsToStrings(tx.Flags),
+//         ...(tx.Holder !== undefined && {
+//           holder: { type: "Address" as const, address: tx.Holder },
+//         }),
+//       }
+//     default:
+//       throw new Error(`Unsupported transaction type: ${tx.TransactionType}`)
+//   }
+// }
 
 /**
  * Converts an XRPL SDK BatchSigners array (from a signed Batch transaction)
  * to the batchSigners format required by the Ripple Custody API.
  */
-export const batchSignersToCustodyBatchSigners = (
-  batchSigners: BatchSigner[],
-): CustodyBatchSigner[] => {
-  return batchSigners.map(({ BatchSigner: { Account, SigningPubKey, TxnSignature } }) => ({
-    account: Account,
-    signingPubKey: SigningPubKey ?? "",
-    txnSignature: TxnSignature ?? "",
-  }))
-}
+// export const batchSignersToCustodyBatchSigners = (
+//   batchSigners: BatchSigner[],
+// ): CustodyBatchSigner[] => {
+//   return batchSigners.map(({ BatchSigner: { Account, SigningPubKey, TxnSignature } }) => ({
+//     account: Account,
+//     signingPubKey: SigningPubKey ?? "",
+//     txnSignature: TxnSignature ?? "",
+//   }))
+// }
 
 /**
  * Converts an XRPL SDK Batch.RawTransactions array to the innerTransactions
@@ -295,15 +292,15 @@ export const batchSignersToCustodyBatchSigners = (
  * Supported transaction types: Payment, OfferCreate, TrustSet, AccountSet, TicketCreate.
  * Throws for any other type.
  */
-export const rawTransactionsToInnerTransactions = (
-  rawTransactions: Batch["RawTransactions"],
-): CustodyInnerTransaction[] => {
-  return rawTransactions.map(({ RawTransaction: tx }) => ({
-    account: tx.Account,
-    ...(tx.Sequence !== undefined && { sequence: tx.Sequence }),
-    ...(tx.TicketSequence !== undefined && {
-      ticketSequence: tx.TicketSequence,
-    }),
-    operation: txToOperation(tx),
-  }))
-}
+// export const rawTransactionsToInnerTransactions = (
+//   rawTransactions: Batch["RawTransactions"],
+// ): CustodyInnerTransaction[] => {
+//   return rawTransactions.map(({ RawTransaction: tx }) => ({
+//     account: tx.Account,
+//     ...(tx.Sequence !== undefined && { sequence: tx.Sequence }),
+//     ...(tx.TicketSequence !== undefined && {
+//       ticketSequence: tx.TicketSequence,
+//     }),
+//     operation: txToOperation(tx),
+//   }))
+// }

--- a/src/services/xrpl/xrpl.service.test.ts
+++ b/src/services/xrpl/xrpl.service.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import type { Batch, SubmittableTransaction } from "xrpl"
-import { encodeForSigningBatch, hashes } from "xrpl"
+import type { SubmittableTransaction } from "xrpl"
+//TODO: restore Batch imports once Batch is supported
+// import type { Batch } from "xrpl"
+// import { encodeForSigningBatch, hashes } from "xrpl"
 import { CustodyError } from "../../models/index.js"
 import type { XrplPorts } from "./xrpl.ports.js"
 import { XrplService } from "./xrpl.service.js"
@@ -9,10 +11,11 @@ import type { IntentContext } from "./xrpl.types.js"
 // Mock the xrpl encoding and hashing functions
 vi.mock("xrpl", () => ({
   encodeForSigning: vi.fn().mockReturnValue("deadbeef01020304"),
-  encodeForSigningBatch: vi.fn().mockReturnValue("batchencoded0102"),
-  hashes: {
-    hashSignedTx: vi.fn().mockReturnValue("TXHASH0123456789"),
-  },
+  //TODO: restore Batch mocks once Batch is supported
+  // encodeForSigningBatch: vi.fn().mockReturnValue("batchencoded0102"),
+  // hashes: {
+  //   hashSignedTx: vi.fn().mockReturnValue("TXHASH0123456789"),
+  // },
 }))
 
 // ── Test helpers ────────────────────────────────────────────────
@@ -286,28 +289,29 @@ describe("XrplService", () => {
       })
     })
 
-    it("should submit a Batch intent", async () => {
-      let capturedBody: any
-      ports = createTestPorts({
-        submitIntent: async (body) => {
-          capturedBody = body
-          return { requestId: "request-123" } as any
-        },
-      })
-      service = new XrplService(ports)
-
-      await service.proposeIntent({
-        Account: mockAddress,
-        operation: {
-          type: "Batch",
-          executionMode: "AllOrNothing",
-          batchSigners: [],
-          innerTransactions: [],
-        },
-      })
-
-      expect(capturedBody.request.payload.parameters.operation.type).toBe("Batch")
-    })
+    //TODO: restore Batch intent test once Batch is supported
+    // it("should submit a Batch intent", async () => {
+    //   let capturedBody: any
+    //   ports = createTestPorts({
+    //     submitIntent: async (body) => {
+    //       capturedBody = body
+    //       return { requestId: "request-123" } as any
+    //     },
+    //   })
+    //   service = new XrplService(ports)
+    //
+    //   await service.proposeIntent({
+    //     Account: mockAddress,
+    //     operation: {
+    //       type: "Batch",
+    //       executionMode: "AllOrNothing",
+    //       batchSigners: [],
+    //       innerTransactions: [],
+    //     },
+    //   })
+    //
+    //   expect(capturedBody.request.payload.parameters.operation.type).toBe("Batch")
+    // })
 
     it("should submit MPTokenIssuanceCreate, MPTokenIssuanceSet, MPTokenIssuanceDestroy intents", async () => {
       let capturedBody: any
@@ -748,130 +752,131 @@ describe("XrplService", () => {
     })
   })
 
-  // ── rawSignInnerBatch ─────────────────────────────────────────
-
-  describe("rawSignInnerBatch", () => {
-    const mockBatch: Batch = {
-      TransactionType: "Batch",
-      Account: "rSubmitterAddress",
-      Flags: 65536,
-      RawTransactions: [
-        {
-          RawTransaction: {
-            TransactionType: "Payment",
-            Account: mockAddress,
-            Destination: "rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH",
-            Amount: "1000000",
-            Fee: "0",
-            Sequence: 0,
-            SigningPubKey: "",
-          },
-        },
-      ],
-    }
-
-    it("should propose a raw sign intent with batch-encoded bytes", async () => {
-      let capturedBody: any
-      ports = createTestPorts({
-        submitIntent: async (body) => {
-          capturedBody = body
-          return { requestId: "r-1" } as any
-        },
-      })
-      service = new XrplService(ports)
-
-      await service.rawSignInnerBatch(mockBatch, mockAddress)
-
-      expect(hashes.hashSignedTx).toHaveBeenCalledWith(mockBatch.RawTransactions[0].RawTransaction)
-      expect(encodeForSigningBatch).toHaveBeenCalledWith(
-        expect.objectContaining({
-          flags: mockBatch.Flags,
-          txIDs: ["TXHASH0123456789"],
-        }),
-      )
-
-      expect(capturedBody.request.type).toBe("Propose")
-      expect(capturedBody.request.payload.type).toBe("v0_SignManifest")
-      expect(capturedBody.request.payload.content.type).toBe("Unsafe")
-      const expectedBase64 = Buffer.from("batchencoded0102", "hex").toString("base64")
-      expect(capturedBody.request.payload.content.value).toBe(expectedBase64)
-    })
-
-    it("should resolve context using signerAddress", async () => {
-      const resolveContext = vi.fn(async () => mockContext)
-      ports = createTestPorts({ resolveContext })
-      service = new XrplService(ports)
-
-      await service.rawSignInnerBatch(mockBatch, mockAddress)
-
-      expect(resolveContext).toHaveBeenCalledWith(mockAddress, { domainId: undefined })
-    })
-
-    it("should throw if signerAddress is not in any inner transaction", async () => {
-      await expect(service.rawSignInnerBatch(mockBatch, "rNotInBatchAddress")).rejects.toThrow(
-        "Address rNotInBatchAddress is not involved in any inner transaction",
-      )
-    })
-  })
-
-  // ── rawSignInnerBatchAndWait ──────────────────────────────────
-
-  describe("rawSignInnerBatchAndWait", () => {
-    const mockBatch: Batch = {
-      TransactionType: "Batch",
-      Account: "rSubmitterAddress",
-      Flags: 65536,
-      RawTransactions: [
-        {
-          RawTransaction: {
-            TransactionType: "Payment",
-            Account: mockAddress,
-            Destination: "rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH",
-            Amount: "1000000",
-            Fee: "0",
-            Sequence: 0,
-            SigningPubKey: "",
-          },
-        },
-      ],
-    }
-
-    it("should sign batch envelope and return signature with signingPubKey", async () => {
-      const result = await service.rawSignInnerBatchAndWait(mockBatch, mockAddress, {
-        polling: { maxRetries: 1, intervalMs: 0 },
-      })
-
-      expect(result.signature).toBe("AABBCCDD")
-      expect(result.signingPubKey).toBe(expectedCompressedKey)
-
-      // xrpl.js BatchSigner format
-      expect(result.batchSigner).toEqual({
-        BatchSigner: {
-          Account: mockAddress,
-          SigningPubKey: expectedCompressedKey,
-          TxnSignature: "AABBCCDD",
-        },
-      })
-
-      // Ripple Custody format
-      expect(result.custodyBatchSigner).toEqual({
-        account: mockAddress,
-        signingPubKey: expectedCompressedKey,
-        txnSignature: "AABBCCDD",
-      })
-    })
-
-    it("should throw CustodyError on timeout", async () => {
-      ports = createTestPorts({
-        getManifest: async () => ({ data: { value: undefined } }) as any,
-      })
-      service = new XrplService(ports)
-
-      await expect(
-        service.rawSignInnerBatchAndWait(mockBatch, mockAddress, {
-          polling: { maxRetries: 2, intervalMs: 0 },
-        }),
-      ).rejects.toThrow("Manifest signature not available after maximum retries")
-    })
-  })
+  //TODO: restore rawSignInnerBatch tests once Batch is supported
+  // // ── rawSignInnerBatch ─────────────────────────────────────────
+  //
+  // describe("rawSignInnerBatch", () => {
+  //   const mockBatch: Batch = {
+  //     TransactionType: "Batch",
+  //     Account: "rSubmitterAddress",
+  //     Flags: 65536,
+  //     RawTransactions: [
+  //       {
+  //         RawTransaction: {
+  //           TransactionType: "Payment",
+  //           Account: mockAddress,
+  //           Destination: "rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH",
+  //           Amount: "1000000",
+  //           Fee: "0",
+  //           Sequence: 0,
+  //           SigningPubKey: "",
+  //         },
+  //       },
+  //     ],
+  //   }
+  //
+  //   it("should propose a raw sign intent with batch-encoded bytes", async () => {
+  //     let capturedBody: any
+  //     ports = createTestPorts({
+  //       submitIntent: async (body) => {
+  //         capturedBody = body
+  //         return { requestId: "r-1" } as any
+  //       },
+  //     })
+  //     service = new XrplService(ports)
+  //
+  //     await service.rawSignInnerBatch(mockBatch, mockAddress)
+  //
+  //     expect(hashes.hashSignedTx).toHaveBeenCalledWith(mockBatch.RawTransactions[0].RawTransaction)
+  //     expect(encodeForSigningBatch).toHaveBeenCalledWith(
+  //       expect.objectContaining({
+  //         flags: mockBatch.Flags,
+  //         txIDs: ["TXHASH0123456789"],
+  //       }),
+  //     )
+  //
+  //     expect(capturedBody.request.type).toBe("Propose")
+  //     expect(capturedBody.request.payload.type).toBe("v0_SignManifest")
+  //     expect(capturedBody.request.payload.content.type).toBe("Unsafe")
+  //     const expectedBase64 = Buffer.from("batchencoded0102", "hex").toString("base64")
+  //     expect(capturedBody.request.payload.content.value).toBe(expectedBase64)
+  //   })
+  //
+  //   it("should resolve context using signerAddress", async () => {
+  //     const resolveContext = vi.fn(async () => mockContext)
+  //     ports = createTestPorts({ resolveContext })
+  //     service = new XrplService(ports)
+  //
+  //     await service.rawSignInnerBatch(mockBatch, mockAddress)
+  //
+  //     expect(resolveContext).toHaveBeenCalledWith(mockAddress, { domainId: undefined })
+  //   })
+  //
+  //   it("should throw if signerAddress is not in any inner transaction", async () => {
+  //     await expect(service.rawSignInnerBatch(mockBatch, "rNotInBatchAddress")).rejects.toThrow(
+  //       "Address rNotInBatchAddress is not involved in any inner transaction",
+  //     )
+  //   })
+  // })
+  //
+  // // ── rawSignInnerBatchAndWait ──────────────────────────────────
+  //
+  // describe("rawSignInnerBatchAndWait", () => {
+  //   const mockBatch: Batch = {
+  //     TransactionType: "Batch",
+  //     Account: "rSubmitterAddress",
+  //     Flags: 65536,
+  //     RawTransactions: [
+  //       {
+  //         RawTransaction: {
+  //           TransactionType: "Payment",
+  //           Account: mockAddress,
+  //           Destination: "rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH",
+  //           Amount: "1000000",
+  //           Fee: "0",
+  //           Sequence: 0,
+  //           SigningPubKey: "",
+  //         },
+  //       },
+  //     ],
+  //   }
+  //
+  //   it("should sign batch envelope and return signature with signingPubKey", async () => {
+  //     const result = await service.rawSignInnerBatchAndWait(mockBatch, mockAddress, {
+  //       polling: { maxRetries: 1, intervalMs: 0 },
+  //     })
+  //
+  //     expect(result.signature).toBe("AABBCCDD")
+  //     expect(result.signingPubKey).toBe(expectedCompressedKey)
+  //
+  //     // xrpl.js BatchSigner format
+  //     expect(result.batchSigner).toEqual({
+  //       BatchSigner: {
+  //         Account: mockAddress,
+  //         SigningPubKey: expectedCompressedKey,
+  //         TxnSignature: "AABBCCDD",
+  //       },
+  //     })
+  //
+  //     // Ripple Custody format
+  //     expect(result.custodyBatchSigner).toEqual({
+  //       account: mockAddress,
+  //       signingPubKey: expectedCompressedKey,
+  //       txnSignature: "AABBCCDD",
+  //     })
+  //   })
+  //
+  //   it("should throw CustodyError on timeout", async () => {
+  //     ports = createTestPorts({
+  //       getManifest: async () => ({ data: { value: undefined } }) as any,
+  //     })
+  //     service = new XrplService(ports)
+  //
+  //     await expect(
+  //       service.rawSignInnerBatchAndWait(mockBatch, mockAddress, {
+  //         polling: { maxRetries: 2, intervalMs: 0 },
+  //       }),
+  //     ).rejects.toThrow("Manifest signature not available after maximum retries")
+  //   })
+  // })
 })

--- a/src/services/xrpl/xrpl.service.ts
+++ b/src/services/xrpl/xrpl.service.ts
@@ -18,7 +18,6 @@ import type {
   IntentContext,
   RawSignAndWaitOptions,
   RawSignAndWaitResult,
-  RawSignInnerBatchAndWaitResult,
   RawSignInnerBatchOptions,
   WaitForSignatureOptions,
   XrplIntentOptions,
@@ -205,48 +204,48 @@ export class XrplService {
    * @throws {CustodyError} If signerAddress is not in the batch, the account is not found,
    *   or the manifest signature is not available after maximum retries
    */
-  public async rawSignInnerBatchAndWait(
-    batch: Batch,
-    signerAddress: string,
-    options: RawSignInnerBatchOptions = {},
-  ): Promise<RawSignInnerBatchAndWaitResult> {
-    this.validateBatchSigner(batch, signerAddress)
+  // public async rawSignInnerBatchAndWait(
+  //   batch: Batch,
+  //   signerAddress: string,
+  //   options: RawSignInnerBatchOptions = {},
+  // ): Promise<RawSignInnerBatchAndWaitResult> {
+  //   this.validateBatchSigner(batch, signerAddress)
 
-    const context = await this.resolveInnerBatchContext(signerAddress, options)
+  //   const context = await this.resolveInnerBatchContext(signerAddress, options)
 
-    const signingPubKey = await this.getPublicKey({
-      domainId: context.domainId,
-      accountId: context.accountId,
-    })
+  //   const signingPubKey = await this.getPublicKey({
+  //     domainId: context.domainId,
+  //     accountId: context.accountId,
+  //   })
 
-    const base64Encoded = this.encodeBatchForSigning(batch)
+  //   const base64Encoded = this.encodeBatchForSigning(batch)
 
-    const { payloadId } = await this.proposeRawSignIntent(base64Encoded, context, options)
+  //   const { payloadId } = await this.proposeRawSignIntent(base64Encoded, context, options)
 
-    const signature = await this.waitForManifestSignature(
-      context.domainId,
-      context.accountId,
-      payloadId,
-      options.polling,
-    )
+  //   const signature = await this.waitForManifestSignature(
+  //     context.domainId,
+  //     context.accountId,
+  //     payloadId,
+  //     options.polling,
+  //   )
 
-    return {
-      signature,
-      signingPubKey,
-      batchSigner: {
-        BatchSigner: {
-          Account: signerAddress,
-          SigningPubKey: signingPubKey,
-          TxnSignature: signature,
-        },
-      },
-      custodyBatchSigner: {
-        account: signerAddress,
-        signingPubKey,
-        txnSignature: signature,
-      },
-    }
-  }
+  //   return {
+  //     signature,
+  //     signingPubKey,
+  //     batchSigner: {
+  //       BatchSigner: {
+  //         Account: signerAddress,
+  //         SigningPubKey: signingPubKey,
+  //         TxnSignature: signature,
+  //       },
+  //     },
+  //     custodyBatchSigner: {
+  //       account: signerAddress,
+  //       signingPubKey,
+  //       txnSignature: signature,
+  //     },
+  //   }
+  // }
 
   /**
    * Resolves the intent context for an inner batch signer.

--- a/src/services/xrpl/xrpl.types.ts
+++ b/src/services/xrpl/xrpl.types.ts
@@ -1,6 +1,5 @@
 import type {
   AccountSet,
-  Batch,
   BatchSigner,
   Clawback,
   DepositPreauth,
@@ -10,7 +9,6 @@ import type {
   MPTokenIssuanceSet,
   OfferCreate,
   Payment,
-  TicketCreate,
   TrustSet,
 } from "xrpl"
 import type { components } from "../../models/custody-types.js"
@@ -94,11 +92,11 @@ export type CustodyOfferCreate = Prettify<
 
 // TicketCreate
 
-export type Core_XrplOperation_TicketCreate =
-  components["schemas"]["Core_XrplOperation_TicketCreate"]
-export type CustodyTicketCreate = Prettify<
-  Pick<TicketCreate, "Account"> & Omit<Core_XrplOperation_TicketCreate, "type">
->
+// export type Core_XrplOperation_TicketCreate =
+//   components["schemas"]["Core_XrplOperation_TicketCreate"]
+// export type CustodyTicketCreate = Prettify<
+//   Pick<TicketCreate, "Account"> & Omit<Core_XrplOperation_TicketCreate, "type">
+// >
 
 // AccountSet
 
@@ -109,14 +107,16 @@ export type CustodyAccountSet = Prettify<
 
 // Batch
 
-export type Core_XrplOperation_Batch = components["schemas"]["Core_XrplOperation_Batch"]
-export type CustodyBatch = Prettify<Pick<Batch, "Account"> & Omit<Core_XrplOperation_Batch, "type">>
+//TODO: delete comment once Batch is supported
+// export type Core_XrplOperation_Batch = components["schemas"]["Core_XrplOperation_Batch"]
+// export type CustodyBatch = Prettify<Pick<Batch, "Account"> & Omit<Core_XrplOperation_Batch, "type">>
 
 // Batch Adapters
 
-export type CustodyBatchSigner = CustodyBatch["batchSigners"][number]
-export type CustodyInnerTransaction = CustodyBatch["innerTransactions"][number]
-export type CustodyOperation = CustodyInnerTransaction["operation"]
+//TODO: delete comment once Batch is supported
+// export type CustodyBatchSigner = CustodyBatch["batchSigners"][number]
+// export type CustodyInnerTransaction = CustodyBatch["innerTransactions"][number]
+// export type CustodyOperation = CustodyInnerTransaction["operation"]
 
 export type CustodyAccountSetFlag = CustodyAccountSet["setFlag"]
 
@@ -201,7 +201,8 @@ export type RawSignInnerBatchAndWaitResult = RawSignAndWaitResult & {
   /** The batch signer in xrpl.js format */
   batchSigner: BatchSigner
   /** The batch signer in Ripple Custody API format */
-  custodyBatchSigner: CustodyBatchSigner
+  //TODO: delete comment once Batch is supported
+  // custodyBatchSigner: CustodyBatchSigner
 }
 
 type BatchSignerLookup = { accountId?: never; ledgerId?: never }

--- a/src/transport/typed-transport.ts
+++ b/src/transport/typed-transport.ts
@@ -51,4 +51,22 @@ export class TypedTransport {
     }
     return this.api.post<T>(resolvedUrl, body, config as AxiosRequestConfig)
   }
+
+  /**
+   * Makes a typed PUT request.
+   * Resolves path params from the URL template before sending.
+   */
+  async put<T>(
+    url: string,
+    body: unknown,
+    pathParams?: Record<string, unknown>,
+    config?: RequestConfig,
+  ): Promise<T> {
+    let resolvedUrl = url
+    if (pathParams && Object.keys(pathParams).length > 0) {
+      const result = splitParams(url, pathParams)
+      resolvedUrl = result.url
+    }
+    return this.api.put<T>(resolvedUrl, body, config as AxiosRequestConfig)
+  }
 }


### PR DESCRIPTION
Batch transaction APIs (rawSignInnerBatch, rawSignInnerBatchAndWait,
batchSignersToCustodyBatchSigners, rawTransactionsToInnerTransactions)
are commented out in this SDK version. Comment the matching tests so the
suite is green, with TODO markers to restore them once Batch is supported.