### PR TITLE
Fix EDS_ChannelCreate type

### DIFF
--- a/.changeset/lovely-masks-lead.md
+++ b/.changeset/lovely-masks-lead.md
@@ -1,0 +1,5 @@
+---
+"custody": patch
+---
+
+The generated EDS_WebhookChannelCreate collapsed to never because the spec's discriminator carries no mapping, so openapi-typescript injects type: "EDS_WebhookChannelCreate" and intersects it with the allOf branch's type?: "WEBHOOK". Compose the type from the generated EDS_ChannelCreate base instead, dropping the poisoned type field and re-pinning it to "WEBHOOK".

--- a/src/services/channels/channels.types.ts
+++ b/src/services/channels/channels.types.ts
@@ -26,9 +26,9 @@ export type EDS_WebhookChannelCreate = Omit<
   components["schemas"]["EDS_ChannelCreate"],
   "type" | "supportedEventTypes"
 > & {
+  supportedEventTypes: (Core_HarmonizeEventPayload["type"] | (string & {}))[]
   type: "WEBHOOK"
   url: string
-  supportedEventTypes: (Core_HarmonizeEventPayload["type"] | (string & {}))[]
 }
 
 /**

--- a/src/services/channels/channels.types.ts
+++ b/src/services/channels/channels.types.ts
@@ -1,4 +1,5 @@
 import type { components, operations } from "../../models/custody-types.js"
+import type { Prettify } from "../../type-utils/index.js"
 
 // Path-param types
 export type GetChannelsPathParams = operations["getAllChannels"]["parameters"]["path"]
@@ -15,10 +16,18 @@ export type GetAllChannelsEventsPathParams = operations["getAllEvents"]["paramet
 export type EDS_Channel = components["schemas"]["EDS_Channel"]
 export type EDS_Event = components["schemas"]["EDS_Event"]
 export type EDS_ChannelUpdate = components["schemas"]["EDS_ChannelUpdate"]
-export type EDS_WebhookChannelCreate = components["schemas"]["EDS_WebhookChannelCreate"]
+// The generated `components["schemas"]["EDS_WebhookChannelCreate"]` is uninhabited:
+// the spec's discriminator has no `mapping`, so openapi-typescript injects
+// `type: "EDS_WebhookChannelCreate"` and intersects it with the allOf branch's
+// `type?: "WEBHOOK"`, collapsing `type` to `never`. Compose from the generated
+// base instead.
+export type EDS_WebhookChannelCreate = Omit<components["schemas"]["EDS_ChannelCreate"], "type"> & {
+  type: "WEBHOOK"
+  url: string
+}
 
 /**
  * Request body for `channels.create`. Modeled as a discriminated union so new
  * channel types (e.g. non-WEBHOOK) can be added without a breaking change.
  */
-export type EDS_ChannelCreate = EDS_WebhookChannelCreate
+export type EDS_ChannelCreate = Prettify<EDS_WebhookChannelCreate>

--- a/src/services/channels/channels.types.ts
+++ b/src/services/channels/channels.types.ts
@@ -1,5 +1,6 @@
 import type { components, operations } from "../../models/custody-types.js"
 import type { Prettify } from "../../type-utils/index.js"
+import type { Core_HarmonizeEventPayload } from "../events/index.js"
 
 // Path-param types
 export type GetChannelsPathParams = operations["getAllChannels"]["parameters"]["path"]
@@ -21,9 +22,13 @@ export type EDS_ChannelUpdate = components["schemas"]["EDS_ChannelUpdate"]
 // `type: "EDS_WebhookChannelCreate"` and intersects it with the allOf branch's
 // `type?: "WEBHOOK"`, collapsing `type` to `never`. Compose from the generated
 // base instead.
-export type EDS_WebhookChannelCreate = Omit<components["schemas"]["EDS_ChannelCreate"], "type"> & {
+export type EDS_WebhookChannelCreate = Omit<
+  components["schemas"]["EDS_ChannelCreate"],
+  "type" | "supportedEventTypes"
+> & {
   type: "WEBHOOK"
   url: string
+  supportedEventTypes: (Core_HarmonizeEventPayload["type"] | (string & {}))[]
 }
 
 /**


### PR DESCRIPTION
The generated `EDS_WebhookChannelCreate` collapsed to `never` because the spec's discriminator carries no `mapping`, so openapi-typescript injects `type: "EDS_WebhookChannelCreate"` and intersects it with the allOf branch's `type?: "WEBHOOK"`. Compose the type from the generated `EDS_ChannelCreate` base instead, dropping the poisoned `type` field and re-pinning it to `"WEBHOOK"`.
