### PR TITLE
Add EDS_WebhookEvent type for webhook delivery envelope

### DIFF
--- a/.changeset/red-ants-shake.md
+++ b/.changeset/red-ants-shake.md
@@ -1,0 +1,5 @@
+---
+"custody": patch
+---
+
+Provides an EDS Webhook Event type that includes traceId and msg. This is a custom type.

--- a/examples/webhooks/create-channel/index.ts
+++ b/examples/webhooks/create-channel/index.ts
@@ -1,0 +1,60 @@
+import { RippleCustody } from "../../../src/index"
+import type { EDS_ChannelCreate } from "../../../src/services/channels/channels.types"
+
+/**
+ * Example: Create a webhook channel on Ripple Custody
+ *
+ * Ripple Custody delivers events to a webhook channel by POSTing them to the
+ * `url` you register here. The URL must be publicly reachable from the Custody
+ * service — for local development, expose your local server with a tunnel
+ * (e.g. `ngrok http 3030`) and use the forwarded HTTPS URL below.
+ *
+ * Pair this example with `../receive-events/index.ts`, which runs a Hono
+ * server on port 3030 and prints each delivered event.
+ */
+const createWebhookChannel = async () => {
+  try {
+    // Initialize the Ripple Custody client with API endpoints and authentication keys
+    // The private and public keys should be securely stored in environment variables
+    const custody = new RippleCustody({
+      apiUrl: "https://custody-api-url",
+      authUrl: "https://custody-auth-url/token",
+      privateKey: process.env.PRIVATE_KEY ?? "",
+      publicKey: process.env.PUBLIC_KEY ?? "",
+    })
+
+    // Retrieve the domain ID and the current user ID — `createdBy` must be a
+    // user that exists in the domain
+    const me = await custody.users.me()
+    const domain = me.domains[0]
+    const domainId = domain.id
+    const createdBy = domain.userReference.id
+
+    const body: EDS_ChannelCreate = {
+      // Generate a fresh UUID for each channel; reusing one will conflict
+      id: "0d6b3b4a-3a7e-4d4c-8e8a-2a3a3b3c3d3e",
+      name: "My webhook channel",
+      type: "WEBHOOK",
+      // Replace with your publicly reachable HTTPS URL (e.g. an ngrok forward)
+      // pointing at the `/webhook` route exposed by `../receive-events`
+      url: "https://<your-ngrok-subdomain>.ngrok-free.app/webhook",
+      // Subscribe to the event variants you care about. `Core_HarmonizeEventPayload["type"]`
+      // is auto-completed by TypeScript — narrow it to just the events your
+      // webhook handler is built to process.
+      supportedEventTypes: ["Core_IntentExecuted", "Core_IntentClosed"],
+      createdBy,
+    }
+
+    const channel = await custody.channels.create({ domainId }, body)
+
+    // The created channel is returned with its server-assigned fields
+    console.dir(channel, { depth: null })
+
+    // Optional: ask Custody to send a test event to verify the URL is reachable
+    if (channel.id) {
+      await custody.channels.test({ domainId, channelId: channel.id })
+    }
+  } catch (error) {
+    console.log(error)
+  }
+}

--- a/examples/webhooks/create-channel/index.ts
+++ b/examples/webhooks/create-channel/index.ts
@@ -41,7 +41,7 @@ const createWebhookChannel = async () => {
       // Subscribe to the event variants you care about. `Core_HarmonizeEventPayload["type"]`
       // is auto-completed by TypeScript — narrow it to just the events your
       // webhook handler is built to process.
-      supportedEventTypes: ["Core_IntentExecuted", "Core_IntentClosed"],
+      supportedEventTypes: ["TransactionCreated", "TransactionUpdated"],
       createdBy,
     }
 

--- a/examples/webhooks/receive-events/index.ts
+++ b/examples/webhooks/receive-events/index.ts
@@ -1,0 +1,52 @@
+// @ts-expect-error - hono is not a dependency of the SDK; install it in your project to run this example
+import { serve } from "@hono/node-server"
+// @ts-expect-error - hono is not a dependency of the SDK; install it in your project to run this example
+import { Hono } from "hono"
+import type { EDS_WebhookEvent } from "../../../src/services/channels/channels.types"
+
+/**
+ * Example: Receive webhook events from Ripple Custody with Hono
+ *
+ * Custody delivers each event as an `EDS_WebhookEvent` envelope:
+ *   {
+ *     traceId: string,            // W3C traceparent for correlation
+ *     msg: Core_HarmonizeEvent    // payload is already a parsed object
+ *   }
+ *
+ * NOTE: The URL registered on the channel must be reachable from the Custody
+ * service. For local testing, run `ngrok http 3030` and register the
+ * forwarded HTTPS URL (with the `/webhook` path) when calling
+ * `custody.channels.create` — see `../create-channel/index.ts`.
+ *
+ * Run this file (e.g. `npx tsx examples/webhooks/receive-events/index.ts`),
+ * then create the channel and trigger an intent to see events arrive.
+ */
+const app = new Hono()
+
+// @ts-expect-error - hono types are unavailable here; `c` is implicitly any
+app.post("/webhook", async (c) => {
+  // @ts-expect-error - generic argument lands on an untyped `c.req.json` call without hono's types
+  const event = await c.req.json<EDS_WebhookEvent>()
+
+  console.dir(event, { depth: null })
+
+  // Switch on the event variant — TypeScript narrows `payload` from the
+  // `Core_HarmonizeEventPayload` union by its `type` discriminator.
+  switch (event.msg.payload.type) {
+    case "Core_IntentExecuted":
+      console.log("Intent executed:", event.msg.payload)
+      break
+    case "Core_IntentClosed":
+      console.log("Intent closed:", event.msg.payload)
+      break
+    default:
+      console.log("Other event:", event.msg.payload.type)
+  }
+
+  return c.json({ received: true })
+})
+
+// @ts-expect-error - hono types are unavailable here; `info` is implicitly any
+serve({ fetch: app.fetch, port: 3030 }, (info) => {
+  console.log(`Listening on http://localhost:${info.port}`)
+})

--- a/examples/webhooks/receive-events/index.ts
+++ b/examples/webhooks/receive-events/index.ts
@@ -30,19 +30,6 @@ app.post("/webhook", async (c) => {
 
   console.dir(event, { depth: null })
 
-  // Switch on the event variant — TypeScript narrows `payload` from the
-  // `Core_HarmonizeEventPayload` union by its `type` discriminator.
-  switch (event.msg.payload.type) {
-    case "Core_IntentExecuted":
-      console.log("Intent executed:", event.msg.payload)
-      break
-    case "Core_IntentClosed":
-      console.log("Intent closed:", event.msg.payload)
-      break
-    default:
-      console.log("Other event:", event.msg.payload.type)
-  }
-
   return c.json({ received: true })
 })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,7 @@ export type {
   EDS_ChannelUpdate,
   EDS_Event,
   EDS_WebhookChannelCreate,
+  EDS_WebhookEvent,
   GetAllChannelsEventsPathParams,
   GetChannelEventPathParams,
   GetChannelEventsPathParams,

--- a/src/services/channels/channels.types.ts
+++ b/src/services/channels/channels.types.ts
@@ -1,6 +1,6 @@
 import type { components, operations } from "../../models/custody-types.js"
 import type { Prettify } from "../../type-utils/index.js"
-import type { Core_HarmonizeEventPayload } from "../events/index.js"
+import type { Core_HarmonizeEvent, Core_HarmonizeEventPayload } from "../events/index.js"
 
 // Path-param types
 export type GetChannelsPathParams = operations["getAllChannels"]["parameters"]["path"]
@@ -36,3 +36,15 @@ export type EDS_WebhookChannelCreate = Omit<
  * channel types (e.g. non-WEBHOOK) can be added without a breaking change.
  */
 export type EDS_ChannelCreate = Prettify<EDS_WebhookChannelCreate>
+
+/**
+ * Body shape delivered to a webhook channel's URL. The outer envelope adds a
+ * W3C `traceId` for distributed tracing; `msg` is a fully-parsed
+ * `Core_HarmonizeEvent` (its `payload` is an object, not a JSON string — this
+ * is distinct from `EDS_Event`, which the REST API returns with `payload` as
+ * a string and which is what `parseEventPayload` operates on).
+ */
+export type EDS_WebhookEvent = {
+  traceId: string
+  msg: Core_HarmonizeEvent
+}


### PR DESCRIPTION
Webhook channels deliver bodies shaped as { traceId, msg } where msg is a fully-parsed Core_HarmonizeEvent — distinct from EDS_Event (REST shape with payload as a JSON string). Without a typed envelope, consumers had to hand-roll the type or cast unknown.