### PR TITLE
`rawSignAndWait` now returns a `signedTransaction` field

### DIFF
--- a/.changeset/bumpy-snakes-leave.md
+++ b/.changeset/bumpy-snakes-leave.md
@@ -2,5 +2,4 @@
 "custody": minor
 ---
 
-`rawSignAndWait` now returns a `signedTransaction` field — the input  
-
+`rawSignAndWait` now returns a `signedTransaction` field — the input transaction with `TxnSignature` and `SigningPubKey` set — so callers receive a ready-to-submit `SubmittableTransaction` without having to manually apply the signature fields.

--- a/.changeset/bumpy-snakes-leave.md
+++ b/.changeset/bumpy-snakes-leave.md
@@ -1,0 +1,6 @@
+---
+"custody": minor
+---
+
+`rawSignAndWait` now returns a `signedTransaction` field — the input  
+

--- a/examples/xrpl/regular-key-mpt-issuance/index.ts
+++ b/examples/xrpl/regular-key-mpt-issuance/index.ts
@@ -1,0 +1,199 @@
+/**
+ * MPT Issuance via SetRegularKey + Disabled Master Key
+ *
+ * This example demonstrates how to issue an MPT (Multi-Purpose Token) using
+ * a regular key setup to separate account ownership from operational control.
+ *
+ * Architecture:
+ * - The issuer account holds the XRP and the master key
+ * - A regular key account's keypair is set as the regular key
+ * - The master key is disabled, leaving only the regular key active
+ * - The regular key holder signs all operational transactions (MPT issuance)
+ *
+ * Benefit: The regular key holder can control the issuer account without
+ * owning or holding any XRP, enabling regulatory compliance scenarios.
+ */
+
+import { RippleCustody } from "custody"
+import {
+  AccountSet,
+  AccountSetAsfFlags,
+  Client,
+  encodeMPTokenMetadata,
+  MPTokenIssuanceCreate,
+  MPTokenIssuanceCreateFlags,
+  SubmittableTransaction,
+} from "xrpl"
+// @ts-expect-error use your own way of importing the keys and URLs
+import { API_URL, AUTH_URL, PRIVATE_KEY, PUBLIC_KEY, XRPL_URL } from "./config"
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+/** The account that will issue the MPT and hold the XRP reserve */
+const MPT_ISSUER_ADDRESS = "rN7n7o...kw6fzRH"
+
+/** The regular key holder account — has signing authority via SetRegularKey */
+const REGULAR_KEY_ACCOUNT = "rU6K7V3P...qTQLWDw1"
+
+// ============================================================================
+// Main Execution Flow
+// ============================================================================
+
+const main = async () => {
+  // Initialize Ripple Custody (for signing with Aviva Fund's key)
+  const custody = new RippleCustody({
+    apiUrl: API_URL,
+    authUrl: AUTH_URL,
+    privateKey: PRIVATE_KEY,
+    publicKey: PUBLIC_KEY,
+  })
+
+  // Initialize XRPL client for transaction submission
+  const client = new Client(XRPL_URL)
+  await client.connect()
+
+  try {
+    console.log("=".repeat(70))
+    console.log("MPT Issuance Setup: SetRegularKey + Disable Master Key")
+    console.log("=".repeat(70))
+
+    // ========================================================================
+    // STEP 1: SetRegularKey — Register regular key on the issuer account
+    // ========================================================================
+    console.log("\n[STEP 1] SetRegularKey: Register regular key holder")
+
+    await submitTransaction(
+      custody,
+      client,
+      {
+        Account: MPT_ISSUER_ADDRESS,
+        TransactionType: "SetRegularKey",
+        RegularKey: REGULAR_KEY_ACCOUNT,
+      },
+      "SetRegularKey transaction submitted",
+    )
+
+    // ========================================================================
+    // STEP 2: AccountSet — Disable the master key
+    // ========================================================================
+    console.log("\n[STEP 2] AccountSet: Disable master key")
+
+    await submitTransaction(
+      custody,
+      client,
+      {
+        Account: MPT_ISSUER_ADDRESS,
+        TransactionType: "AccountSet",
+        SetFlag: AccountSetAsfFlags.asfDisableMaster,
+      } as AccountSet,
+      "Master key disabled — only regular key can now sign",
+    )
+
+    // ========================================================================
+    // STEP 3: MPTokenIssuanceCreate — Issue the MPT
+    // ========================================================================
+    console.log("\n[STEP 3] MPTokenIssuanceCreate: Issue the MPT")
+
+    const mptTxn: MPTokenIssuanceCreate = {
+      Account: MPT_ISSUER_ADDRESS,
+      TransactionType: "MPTokenIssuanceCreate",
+
+      // Token supply: maximum 100,000 units, define your own
+      MaximumAmount: "100000",
+
+      // Asset scale: 0 decimal places, define your own
+      AssetScale: 0,
+
+      // Permissions: allow clawback, transfer, lock, trade, and escrow, define your flags
+      Flags:
+        MPTokenIssuanceCreateFlags.tfMPTCanClawback |
+        MPTokenIssuanceCreateFlags.tfMPTCanTransfer |
+        MPTokenIssuanceCreateFlags.tfMPTCanLock |
+        MPTokenIssuanceCreateFlags.tfMPTCanTrade |
+        MPTokenIssuanceCreateFlags.tfMPTCanEscrow,
+
+      // Metadata: rich information about the token
+      MPTokenMetadata: encodeMPTokenMetadata({
+        ticker: "TOK",
+        name: "Token",
+        desc: "Real-world asset backed token",
+        icon: "https://example.com/icon.png",
+        asset_class: "rwa",
+        asset_subclass: "stablecoin",
+        issuer_name: "Token Issuer",
+      }),
+    }
+
+    await submitTransaction(
+      custody,
+      client,
+      mptTxn,
+      "MPT issuance successful",
+      REGULAR_KEY_ACCOUNT, // Pass signer account for MPT issuance
+    )
+
+    console.log("\n" + "=".repeat(70))
+    console.log("✓ All steps completed successfully")
+    console.log("=".repeat(70))
+    console.log("\nResult: Regular key holder now controls the MPT issuer account")
+    console.log("without owning or holding any XRP directly.")
+  } finally {
+    await client.disconnect()
+  }
+}
+
+// ============================================================================
+// Helper: Submit Transaction
+// ============================================================================
+
+/**
+ * Submits a transaction to the XRPL:
+ * 1. Autofill with current ledger state (fee, sequence, etc.)
+ * 2. Sign with Ripple Custody
+ * 3. Submit and wait for ledger confirmation
+ *
+ * @param custody - RippleCustody instance for signing
+ * @param client - XRPL Client for submission
+ * @param txn - The transaction to submit
+ * @param successMessage - Message to log on success
+ * @param signerAccount - Optional: account to sign with (e.g., for regular key)
+ */
+const submitTransaction = async (
+  custody: RippleCustody,
+  client: Client,
+  txn: SubmittableTransaction,
+  successMessage: string,
+  signerAccount?: string,
+): Promise<void> => {
+  try {
+    // Step 1: Autofill transaction with current ledger state
+    // This populates Fee, Sequence, and other required fields
+    const autofilled = await client.autofill(txn)
+
+    // Step 2: Sign the transaction using Ripple Custody
+    console.log(`  Signing with Ripple Custody...`)
+    const { signedTransaction } = await custody.xrpl.rawSignAndWait(autofilled, {
+      signerAccount: signerAccount ?? undefined,
+    })
+
+    // Step 3: Submit the signed transaction to the XRPL
+    // Wait for ledger confirmation before returning
+    console.log(`  Submitting to ledger...`)
+    const response = await client.submitAndWait(signedTransaction)
+
+    // Log success
+    console.log(`  ✓ ${successMessage}`)
+    console.log(`  Hash: ${response.result.hash}`)
+  } catch (error) {
+    console.error(`  ✗ Transaction failed:`, error)
+    throw error
+  }
+}
+
+// ============================================================================
+// Execution
+// ============================================================================
+
+main().catch(console.error)

--- a/src/services/xrpl/xrpl.service.test.ts
+++ b/src/services/xrpl/xrpl.service.test.ts
@@ -268,26 +268,27 @@ describe("XrplService", () => {
       })
     })
 
-    it("should submit a TicketCreate intent", async () => {
-      let capturedBody: any
-      ports = createTestPorts({
-        submitIntent: async (body) => {
-          capturedBody = body
-          return { requestId: "request-123" } as any
-        },
-      })
-      service = new XrplService(ports)
+    // TODO: Restore ticketCreate when it is in an official release
+    // it("should submit a TicketCreate intent", async () => {
+    //   let capturedBody: any
+    //   ports = createTestPorts({
+    //     submitIntent: async (body) => {
+    //       capturedBody = body
+    //       return { requestId: "request-123" } as any
+    //     },
+    //   })
+    //   service = new XrplService(ports)
 
-      await service.proposeIntent({
-        Account: mockAddress,
-        operation: { type: "TicketCreate", ticketCount: 5 },
-      })
+    //   await service.proposeIntent({
+    //     Account: mockAddress,
+    //     operation: { type: "TicketCreate", ticketCount: 5 },
+    //   })
 
-      expect(capturedBody.request.payload.parameters.operation).toMatchObject({
-        type: "TicketCreate",
-        ticketCount: 5,
-      })
-    })
+    //   expect(capturedBody.request.payload.parameters.operation).toMatchObject({
+    //     type: "TicketCreate",
+    //     ticketCount: 5,
+    //   })
+    // })
 
     //TODO: restore Batch intent test once Batch is supported
     // it("should submit a Batch intent", async () => {
@@ -678,6 +679,8 @@ describe("XrplService", () => {
       expect(result.signature).toBe("AABBCCDD")
       expect(result.signingPubKey).toBe(expectedCompressedKey)
       expect(tx.SigningPubKey).toBe(expectedCompressedKey)
+      expect(result.signedTransaction.TxnSignature).toBe("AABBCCDD")
+      expect(result.signedTransaction.SigningPubKey).toBe(expectedCompressedKey)
     })
 
     it("should not override SigningPubKey if already set", async () => {
@@ -692,6 +695,8 @@ describe("XrplService", () => {
 
       expect(result.signingPubKey).toBe("EXISTING_PUB_KEY")
       expect(getAccount).not.toHaveBeenCalled()
+      expect(result.signedTransaction.TxnSignature).toBe("AABBCCDD")
+      expect(result.signedTransaction.SigningPubKey).toBe("EXISTING_PUB_KEY")
     })
 
     it("should throw CustodyError on timeout", async () => {
@@ -749,6 +754,7 @@ describe("XrplService", () => {
       })
 
       expect(result.signature).toBe("AABBCCDD")
+      expect(result.signedTransaction.TxnSignature).toBe("AABBCCDD")
     })
   })
 

--- a/src/services/xrpl/xrpl.service.test.ts
+++ b/src/services/xrpl/xrpl.service.test.ts
@@ -763,9 +763,9 @@ describe("XrplService", () => {
 
     it("should throw CustodyError if signerAccount is not a valid XRPL address", async () => {
       const tx = { ...mockXrplTransaction, SigningPubKey: "PK" }
-      await expect(
-        service.rawSignAndWait(tx, { signerAccount: "not-an-address" }),
-      ).rejects.toThrow("Invalid signerAccount address: not-an-address")
+      await expect(service.rawSignAndWait(tx, { signerAccount: "not-an-address" })).rejects.toThrow(
+        "Invalid signerAccount address: not-an-address",
+      )
     })
 
     it("should use signerAccount to resolve context and build intent", async () => {
@@ -806,14 +806,19 @@ describe("XrplService", () => {
         address: signerAddress,
       }
       const resolveContext = vi.fn(async () => signerContext)
-      const getAccount = vi.fn(async () => ({
-        data: {
-          providerDetails: {
-            type: "Vault" as const,
-            keys: [{ id: "SECP256K1_CUSTODY_1" as const, publicKey: { value: mockBase64PublicKey } }],
-          },
-        },
-      } as any))
+      const getAccount = vi.fn(
+        async () =>
+          ({
+            data: {
+              providerDetails: {
+                type: "Vault" as const,
+                keys: [
+                  { id: "SECP256K1_CUSTODY_1" as const, publicKey: { value: mockBase64PublicKey } },
+                ],
+              },
+            },
+          }) as any,
+      )
       ports = createTestPorts({ resolveContext, getAccount })
       service = new XrplService(ports)
 

--- a/src/services/xrpl/xrpl.service.test.ts
+++ b/src/services/xrpl/xrpl.service.test.ts
@@ -9,14 +9,18 @@ import { XrplService } from "./xrpl.service.js"
 import type { IntentContext } from "./xrpl.types.js"
 
 // Mock the xrpl encoding and hashing functions
-vi.mock("xrpl", () => ({
-  encodeForSigning: vi.fn().mockReturnValue("deadbeef01020304"),
-  //TODO: restore Batch mocks once Batch is supported
-  // encodeForSigningBatch: vi.fn().mockReturnValue("batchencoded0102"),
-  // hashes: {
-  //   hashSignedTx: vi.fn().mockReturnValue("TXHASH0123456789"),
-  // },
-}))
+vi.mock("xrpl", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("xrpl")>()
+  return {
+    encodeForSigning: vi.fn().mockReturnValue("deadbeef01020304"),
+    isValidAddress: actual.isValidAddress,
+    //TODO: restore Batch mocks once Batch is supported
+    // encodeForSigningBatch: vi.fn().mockReturnValue("batchencoded0102"),
+    // hashes: {
+    //   hashSignedTx: vi.fn().mockReturnValue("TXHASH0123456789"),
+    // },
+  }
+})
 
 // ── Test helpers ────────────────────────────────────────────────
 
@@ -755,6 +759,72 @@ describe("XrplService", () => {
 
       expect(result.signature).toBe("AABBCCDD")
       expect(result.signedTransaction.TxnSignature).toBe("AABBCCDD")
+    })
+
+    it("should throw CustodyError if signerAccount is not a valid XRPL address", async () => {
+      const tx = { ...mockXrplTransaction, SigningPubKey: "PK" }
+      await expect(
+        service.rawSignAndWait(tx, { signerAccount: "not-an-address" }),
+      ).rejects.toThrow("Invalid signerAccount address: not-an-address")
+    })
+
+    it("should use signerAccount to resolve context and build intent", async () => {
+      const signerAddress = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+      const signerContext: IntentContext = {
+        ...mockContext,
+        accountId: "signer-account-id",
+        ledgerId: "signer-ledger-id",
+        address: signerAddress,
+      }
+      const resolveContext = vi.fn(async () => signerContext)
+      let capturedBody: any
+      ports = createTestPorts({
+        resolveContext,
+        submitIntent: async (body) => {
+          capturedBody = body
+          return { requestId: "r" } as any
+        },
+      })
+      service = new XrplService(ports)
+
+      const tx = { ...mockXrplTransaction, SigningPubKey: "EXISTING_PUB_KEY" }
+      await service.rawSignAndWait(tx, {
+        signerAccount: signerAddress,
+        polling: { maxRetries: 1, intervalMs: 0 },
+      })
+
+      expect(resolveContext).toHaveBeenCalledWith(signerAddress, { domainId: undefined })
+      expect(capturedBody.request.payload.accountId).toBe("signer-account-id")
+      expect(capturedBody.request.payload.ledgerId).toBe("signer-ledger-id")
+    })
+
+    it("should fetch SigningPubKey from signerAccount when not pre-set", async () => {
+      const signerAddress = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"
+      const signerContext: IntentContext = {
+        ...mockContext,
+        accountId: "signer-account-id",
+        address: signerAddress,
+      }
+      const resolveContext = vi.fn(async () => signerContext)
+      const getAccount = vi.fn(async () => ({
+        data: {
+          providerDetails: {
+            type: "Vault" as const,
+            keys: [{ id: "SECP256K1_CUSTODY_1" as const, publicKey: { value: mockBase64PublicKey } }],
+          },
+        },
+      } as any))
+      ports = createTestPorts({ resolveContext, getAccount })
+      service = new XrplService(ports)
+
+      const tx = { ...mockXrplTransaction }
+      const result = await service.rawSignAndWait(tx, {
+        signerAccount: signerAddress,
+        polling: { maxRetries: 1, intervalMs: 0 },
+      })
+
+      expect(getAccount).toHaveBeenCalledWith(signerContext.domainId, "signer-account-id")
+      expect(result.signingPubKey).toBe(expectedCompressedKey)
     })
   })
 

--- a/src/services/xrpl/xrpl.service.ts
+++ b/src/services/xrpl/xrpl.service.ts
@@ -5,6 +5,7 @@ import {
   encodeForSigning,
   encodeForSigningBatch,
   hashes,
+  isValidAddress,
   type Batch,
   type SubmittableTransaction,
 } from "xrpl"
@@ -129,7 +130,12 @@ export class XrplService {
     xrplTransaction: SubmittableTransaction,
     options: RawSignAndWaitOptions = {},
   ): Promise<RawSignAndWaitResult> {
-    const context = await this.ports.resolveContext(xrplTransaction.Account, {
+    if (options.signerAccount !== undefined && !isValidAddress(options.signerAccount)) {
+      throw new CustodyError({ reason: `Invalid signerAccount address: ${options.signerAccount}` })
+    }
+
+    const signerAddress = options.signerAccount ?? xrplTransaction.Account
+    const context = await this.ports.resolveContext(signerAddress, {
       domainId: options.domainId,
     })
 

--- a/src/services/xrpl/xrpl.service.ts
+++ b/src/services/xrpl/xrpl.service.ts
@@ -121,7 +121,7 @@ export class XrplService {
    *
    * @param xrplTransaction - The XRPL transaction details
    * @param options - Optional configuration for the raw sign intent and polling
-   * @returns The signature and signing public key in uppercase hex
+   * @returns The signature, signing public key in uppercase hex and the signed transaction
    * @throws {CustodyError} If validation fails, the sender account is not found,
    *   or the manifest signature is not available after maximum retries
    */
@@ -153,9 +153,12 @@ export class XrplService {
       options.polling,
     )
 
+    xrplTransaction.TxnSignature = signature
+
     return {
       signature,
       signingPubKey: xrplTransaction.SigningPubKey,
+      signedTransaction: xrplTransaction,
     }
   }
 

--- a/src/services/xrpl/xrpl.service.ts
+++ b/src/services/xrpl/xrpl.service.ts
@@ -10,6 +10,7 @@ import {
   type SubmittableTransaction,
 } from "xrpl"
 import { sleep } from "../../helpers/async/async.js"
+import { isUndefined } from "../../helpers/index.js"
 import { CustodyError } from "../../models/index.js"
 import type { Core_IntentResponse, Core_ProposeIntentBody } from "../intents/intents.types.js"
 import type { XrplPorts } from "./xrpl.ports.js"
@@ -130,7 +131,7 @@ export class XrplService {
     xrplTransaction: SubmittableTransaction,
     options: RawSignAndWaitOptions = {},
   ): Promise<RawSignAndWaitResult> {
-    if (options.signerAccount !== undefined && !isValidAddress(options.signerAccount)) {
+    if (!isUndefined(options.signerAccount) && !isValidAddress(options.signerAccount)) {
       throw new CustodyError({ reason: `Invalid signerAccount address: ${options.signerAccount}` })
     }
 

--- a/src/services/xrpl/xrpl.types.ts
+++ b/src/services/xrpl/xrpl.types.ts
@@ -9,6 +9,7 @@ import type {
   MPTokenIssuanceSet,
   OfferCreate,
   Payment,
+  SubmittableTransaction,
   TrustSet,
 } from "xrpl"
 import type { components } from "../../models/custody-types.js"
@@ -191,6 +192,8 @@ export type RawSignAndWaitResult = {
   signature: string
   /** The compressed secp256k1 public key in uppercase hex */
   signingPubKey: string
+  /** The transaction with TxnSignature and SigningPubKey set, ready to submit */
+  signedTransaction: SubmittableTransaction
 }
 
 /**

--- a/src/services/xrpl/xrpl.types.ts
+++ b/src/services/xrpl/xrpl.types.ts
@@ -182,6 +182,12 @@ export type WaitForSignatureOptions = {
 export type RawSignAndWaitOptions = XrplIntentOptions & {
   /** Polling options for waiting for the manifest signature */
   polling?: WaitForSignatureOptions
+  /**
+   * XRPL address of the account whose custody key will sign the transaction.
+   * Defaults to xrplTransaction.Account. Set this when the account has a regular key
+   * (via SetRegularKey) and you want to sign with that regular key's custody account.
+   */
+  signerAccount?: string
 }
 
 /**


### PR DESCRIPTION
`rawSignAndWait` now returns a `signedTransaction` field — the input transaction with `TxnSignature` and `SigningPubKey` set — so callers  receive a ready-to-submit `SubmittableTransaction` without having to  manually apply the signature fields. 