### PR TITLE
Add endpoints namespace

### DIFF
--- a/.changeset/endpoints-namespace.md
+++ b/.changeset/endpoints-namespace.md
@@ -1,0 +1,9 @@
+---
+"custody": minor
+---
+
+Added an `endpoints` namespace exposing the domain-scoped Endpoints API.
+
+- `client.endpoints.list({ domainId }, query?)` returns `Core_TrustedEndpointsCollection`, backed by `GET /v1/domains/{domainId}/endpoints` (`getEndpoints`). The optional query bag supports paging (`limit`, `startingAfter`), sorting (`sortBy`, `sortOrder`), and the same metadata / `ledgerId` / `alias` / `address` / `lock` filters defined in the OpenAPI spec.
+- `client.endpoints.get({ domainId, endpointId })` returns `Core_TrustedEndpoint`, backed by `GET /v1/domains/{domainId}/endpoints/{endpointId}` (`getEndpoint`).
+- New public type exports from the SDK barrel: `Core_TrustedEndpoint`, `Core_TrustedEndpointsCollection`, `GetEndpointPathParams`, `GetEndpointsPathParams`, `GetEndpointsQueryParams`.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A comprehensive JavaScript/Typescript SDK for interacting with the Ripple Custod
 
 - **Cryptographic Support**: Ed25519, secp256k1, secp256r1 keypair generation and signing
 - **Domain Management**: List and retrieve domain information
+- **Endpoint Management**: List and retrieve endpoints within a domain
 - **Intent Operations**: Propose, approve, reject, and manage intents with built-in polling
 - **Account Management**: Manage accounts, addresses, and balances
 - **Transaction Operations**: Handle transaction orders, transfers, and dry runs
@@ -90,6 +91,16 @@ The SDK provides a namespaced API for easy discovery and usage:
 // Domain Operations
 const domains = await custody.domains.list()
 const domain = await custody.domains.get({ domainId: "your-domain-id" })
+
+// Endpoint Operations
+const endpoints = await custody.endpoints.list(
+  { domainId: "domain-id" },
+  { limit: 10, sortBy: "alias" },
+)
+const endpoint = await custody.endpoints.get({
+  domainId: "domain-id",
+  endpointId: "endpoint-id",
+})
 
 // Intent Operations
 const intent = await custody.intents.propose({

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "xrpl": "^4.6.0"
   },
   "devDependencies": {
-    "@arethetypeswrong/cli": "^0.18.1",
+    "@arethetypeswrong/cli": "^0.18.2",
     "@changesets/cli": "^2.29.6",
     "@types/qs": "^6.14.0",
     "@vitest/coverage-v8": "^3.1.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,15 @@ export type {
   GetDomainsQueryParams,
 } from "./services/domains/index.js"
 
+// endpoints types
+export type {
+  Core_TrustedEndpoint,
+  Core_TrustedEndpointsCollection,
+  GetEndpointPathParams,
+  GetEndpointsPathParams,
+  GetEndpointsQueryParams,
+} from "./services/endpoints/index.js"
+
 // events types
 export type {
   Core_EventScope,

--- a/src/namespaces/endpoints.ts
+++ b/src/namespaces/endpoints.ts
@@ -1,0 +1,21 @@
+import { URLs } from "../constants/urls.js"
+import type {
+  Core_TrustedEndpoint,
+  Core_TrustedEndpointsCollection,
+  GetEndpointPathParams,
+  GetEndpointsPathParams,
+  GetEndpointsQueryParams,
+} from "../services/endpoints/endpoints.types.js"
+import type { TypedTransport } from "../transport/index.js"
+
+export function createEndpoints(t: TypedTransport) {
+  return {
+    list: (
+      params: GetEndpointsPathParams,
+      query?: GetEndpointsQueryParams,
+    ): Promise<Core_TrustedEndpointsCollection> => t.get(URLs.endpoints, params, query),
+
+    get: (params: GetEndpointPathParams): Promise<Core_TrustedEndpoint> =>
+      t.get(URLs.endpoint, params),
+  } as const
+}

--- a/src/namespaces/index.ts
+++ b/src/namespaces/index.ts
@@ -1,6 +1,7 @@
 export { createAccounts, findByAddress, findByAddressOrThrow } from "./accounts.js"
 export { createChannels } from "./channels.js"
 export { createDomains } from "./domains.js"
+export { createEndpoints } from "./endpoints.js"
 export { createEvents } from "./events.js"
 export { createGenesis } from "./genesis.js"
 export { createIntents } from "./intents.js"

--- a/src/ripple-custody.ts
+++ b/src/ripple-custody.ts
@@ -3,6 +3,7 @@ import {
   createAccounts,
   createChannels,
   createDomains,
+  createEndpoints,
   createEvents,
   createGenesis,
   createIntents,
@@ -45,6 +46,7 @@ export class RippleCustody {
   // Namespace objects built from factory functions
   public readonly channels: ReturnType<typeof createChannels>
   public readonly domains: ReturnType<typeof createDomains>
+  public readonly endpoints: ReturnType<typeof createEndpoints>
   public readonly events: ReturnType<typeof createEvents>
   public readonly genesis: ReturnType<typeof createGenesis>
   public readonly intents: ReturnType<typeof createIntents>
@@ -77,6 +79,7 @@ export class RippleCustody {
     // Initialize namespaces from factories
     this.channels = createChannels(this.transport)
     this.domains = createDomains(this.transport)
+    this.endpoints = createEndpoints(this.transport)
     this.events = createEvents(this.transport)
     this.genesis = createGenesis(this.transport)
     this.intents = createIntents(this.transport)

--- a/src/services/endpoints/endpoints.types.ts
+++ b/src/services/endpoints/endpoints.types.ts
@@ -1,0 +1,11 @@
+import type { components, operations } from "../../models/custody-types.js"
+
+// Request types
+export type GetEndpointsPathParams = operations["getEndpoints"]["parameters"]["path"]
+export type GetEndpointsQueryParams = operations["getEndpoints"]["parameters"]["query"]
+export type GetEndpointPathParams = operations["getEndpoint"]["parameters"]["path"]
+
+// Response types
+export type Core_TrustedEndpointsCollection =
+  components["schemas"]["Core_TrustedEndpointsCollection"]
+export type Core_TrustedEndpoint = components["schemas"]["Core_TrustedEndpoint"]

--- a/src/services/endpoints/index.ts
+++ b/src/services/endpoints/index.ts
@@ -1,0 +1,1 @@
+export * from "./endpoints.types.js"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,9 +19,9 @@
     "module": "NodeNext",
     "outDir": "dist",
     "rootDir": "src",
-    "sourceMap": true,
+    "sourceMap": false,
     "declaration": true,
-    "declarationMap": true
+    "declarationMap": false
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "**/*.test.ts"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,9 +19,9 @@
     "module": "NodeNext",
     "outDir": "dist",
     "rootDir": "src",
-    "sourceMap": false,
+    "sourceMap": true,
     "declaration": true,
-    "declarationMap": false
+    "declarationMap": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "**/*.test.ts"]


### PR DESCRIPTION
## Summary
- New `client.endpoints.list({ domainId }, query?)` and `client.endpoints.get({ domainId, endpointId })`, wrapping the existing `getEndpoints` / `getEndpoint` OpenAPI operations. Mirrors the `domains` list+get pattern (thin `createEndpoints` factory + types-only `src/services/endpoints/` folder, all derived from `custody-types.ts`).
- Public type exports added to the SDK barrel: `Core_TrustedEndpoint`, `Core_TrustedEndpointsCollection`, `GetEndpointPathParams`, `GetEndpointsPathParams`, `GetEndpointsQueryParams`.
- README gains a Features bullet and an Endpoint Operations example next to Domain Operations.
- Minor changeset added (non-breaking surface addition).

## Test plan
- [ ] `npm run build` passes (typecheck clean locally)
- [ ] Spot-check autocomplete: `client.endpoints.list({ domainId })` and `client.endpoints.get({ domainId, endpointId })` resolve with the right param and return types
- [ ] Hit a live custody backend and confirm `list` and `get` round-trip a real endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)