### PR TITLE
ci: auto-publish to npm on Version Packages PR merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -24,16 +25,18 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "22"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: npm install
 
-      - name: Create Release Pull Request or Tag
+      - name: Create Release Pull Request or Publish to npm
         uses: changesets/action@v1
         with:
           title: "chore: version packages"
           commit: "chore: version packages"
-          # This creates git tags and GitHub Releases without publishing to npm
-          publish: npx changeset tag
+          publish: npm run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: "true"

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "generate:custody-types": "npx openapi-typescript ./openapi/Ripple-Custody-v1-OpenAPI.json -o ./src/models/custody-types.ts && prettier --write ./src/models/custody-types.ts",
     "local-release": "changeset version && changeset publish",
     "prepare": "npm run build",
+    "release": "changeset publish",
     "prepublishOnly": "npm run build && npm run check-format && npm run test",
     "sort-package": "npx sort-package-json",
     "start": "npm run build && node dist/main.js",


### PR DESCRIPTION
## Summary
- Extend the existing changesets release workflow to publish to npm — previously it only created git tags / GitHub Releases (`npx changeset tag`) and required a manual `npm publish` afterward.
- Add `id-token: write` permission and `NPM_CONFIG_PROVENANCE=true` so published artifacts include npm provenance attestation.
- Wire `NPM_TOKEN` (already set as a repo secret) through `NODE_AUTH_TOKEN`, with `registry-url` configured on `setup-node` so npm auth resolves correctly.
- Add a `release` npm script (`changeset publish`) so the workflow has a single entry point. `prepublishOnly` already runs build + check-format + test, so a broken artifact can't ship.

## How releases will work after this merges
1. PRs add changeset files as today.
2. On push to `main`, the workflow opens (or updates) a "Version Packages" PR with the bumped version + changelog.
3. Merging that PR triggers the workflow again — this time it runs `changeset publish`, which tags the release **and** publishes to npm with provenance.

## Test plan
- [ ] Merge this PR. The Release workflow should run on `main` and either no-op (no pending changesets) or open/update a Version Packages PR.
- [ ] When a Version Packages PR is later merged, confirm the workflow publishes the new version to https://www.npmjs.com/package/@florent-uzio/custody and that the published version page shows a provenance badge.
- [ ] Verify the git tag for the released version is created on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)