### PR TITLE
docs(examples): validate MPT metadata before submission

### DIFF
--- a/examples/xrpl/mpt/create/index.ts
+++ b/examples/xrpl/mpt/create/index.ts
@@ -1,4 +1,4 @@
-import { encodeMPTokenMetadata } from "xrpl"
+import { encodeMPTokenMetadata, validateMPTokenMetadata } from "xrpl"
 import { RippleCustody } from "../../../../src"
 
 const createMpt = async () => {
@@ -23,6 +23,25 @@ const createMpt = async () => {
     // Can be used to filter the transactions
     const orderReferenceId = crypto.randomUUID()
 
+    // Encode the MPT metadata as hex per XLS-89 and validate it before submission.
+    // validateMPTokenMetadata returns an array of warning messages — empty means valid.
+    // It enforces the 1024-byte ceiling and flags XLS-89 formatting issues that would
+    // otherwise make the token undiscoverable by explorers and indexers.
+    const metadata = encodeMPTokenMetadata({
+      ticker: "ABC",
+      name: "Token ABC",
+      desc: "This is a token ABC",
+      icon: "https://link.com",
+      asset_class: "rwa",
+      asset_subclass: "stablecoin",
+      issuer_name: "your name",
+    })
+
+    const validationMessages = validateMPTokenMetadata(metadata)
+    if (validationMessages.length > 0) {
+      throw new Error(`Invalid MPTokenMetadata:\n- ${validationMessages.join("\n- ")}`)
+    }
+
     // Submit the MPTokenIssuanceCreate transaction to Ripple Custody
     // The transaction will be queued as an "intent" and processed asynchronously
     await custody.xrpl.proposeIntent(
@@ -31,14 +50,7 @@ const createMpt = async () => {
         operation: {
           type: "MPTokenIssuanceCreate",
           metadata: {
-            value: encodeMPTokenMetadata({
-              ticker: "ABC",
-              name: "Token ABC",
-              desc: "This is a token ABC",
-              icon: "https://link.com",
-              asset_class: "rwa",
-              issuer_name: "your name",
-            }),
+            value: metadata,
             type: "HexEncodedMetadata",
           },
           flags: ["tfMPTCanTransfer", "tfMPTCanLock"],


### PR DESCRIPTION
## Summary
- Use xrpl.js's `validateMPTokenMetadata` in the `MPTokenIssuanceCreate` example to catch the 1024-byte cap and XLS-89 formatting issues client-side, before the request reaches the custody server.
- Extract the encoded metadata into a `const metadata` so it is encoded once and reused.
- Add `asset_subclass: "stablecoin"` to the example payload — XLS-89 requires `asset_subclass` whenever `asset_class === "rwa"`, so the example would otherwise fail its own validation.

## Test plan
- [ ] `npm run build` succeeds
- [ ] Manually run `examples/xrpl/mpt/create/index.ts` against a test domain and confirm the intent is submitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)