### PR TITLE
fix: flatten intent polling retry logic in waitForExecution

### DIFF
--- a/.changeset/flatten-intent-polling.md
+++ b/.changeset/flatten-intent-polling.md
@@ -1,0 +1,17 @@
+---
+"@florent-uzio/custody": patch
+---
+
+fix: flatten intent polling retry logic in `waitForExecution` (`intents.getAndWait`)
+
+The nested `getIntentWithRetry` loop would throw a 404 that bypassed the outer
+`waitForExecution` retry loop, causing `getAndWait` to fail immediately when the
+intent was not yet available (e.g. right after proposing) instead of polling for it.
+
+- Merged `getIntentWithRetry` into `waitForExecution` as a single retry loop that
+  treats a 404 as "not available yet" and keeps polling until `maxRetries`.
+- A persistent 404 (intent never materializes) now throws a `CustodyError` with
+  `statusCode` 404 after `maxRetries` attempts.
+- Fixed the timeout path: the result is now derived from the last observed intent,
+  so it can no longer report a terminal status with `isTerminal: false`.
+- Removed `notFoundRetries` and `notFoundIntervalMs` from `WaitForExecutionOptions`.

--- a/.changeset/flatten-intent-polling.md
+++ b/.changeset/flatten-intent-polling.md
@@ -1,5 +1,5 @@
 ---
-"@florent-uzio/custody": patch
+"@florent-uzio/custody": minor
 ---
 
 fix: flatten intent polling retry logic in `waitForExecution` (`intents.getAndWait`)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,9 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: npm install
 
@@ -38,5 +41,4 @@ jobs:
           publish: npm run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"

--- a/src/namespaces/__tests__/intents.test.ts
+++ b/src/namespaces/__tests__/intents.test.ts
@@ -72,7 +72,8 @@ describe("createIntents", () => {
 
       const result = await intents.getAndWait(params, { maxRetries: 2 })
 
-      // 2 attempts in main loop + 1 final fetch
+      // 2 attempts in the polling loop, no extra fetch afterwards
+      expect(mockTransport.get).toHaveBeenCalledTimes(2)
       expect(result.isTerminal).toBe(false)
       expect(result.isSuccess).toBe(false)
       expect(result.status).toBe("Executing")
@@ -118,12 +119,33 @@ describe("createIntents", () => {
         .mockRejectedValueOnce(notFoundError)
         .mockResolvedValueOnce({ data: { state: { status: "Executed" } } })
 
-      const result = await intents.getAndWait(params, {
-        notFoundRetries: 3,
-        notFoundIntervalMs: 100,
-      })
+      const result = await intents.getAndWait(params)
 
       expect(result.isSuccess).toBe(true)
+    })
+
+    it("should keep polling through repeated 404s until terminal (regression)", async () => {
+      const notFoundError = new CustodyError({ reason: "Not found" }, 404)
+      mockTransport.get
+        .mockRejectedValueOnce(notFoundError)
+        .mockRejectedValueOnce(notFoundError)
+        .mockRejectedValueOnce(notFoundError)
+        .mockRejectedValueOnce(notFoundError)
+        .mockResolvedValueOnce({ data: { state: { status: "Executed" } } })
+
+      const result = await intents.getAndWait(params, { maxRetries: 10 })
+
+      expect(result.isSuccess).toBe(true)
+      expect(mockTransport.get).toHaveBeenCalledTimes(5)
+    })
+
+    it("should throw 404 when the intent never materializes", async () => {
+      const notFoundError = new CustodyError({ reason: "Not found" }, 404)
+      mockTransport.get.mockRejectedValue(notFoundError)
+
+      await expect(intents.getAndWait(params, { maxRetries: 2 })).rejects.toMatchObject({
+        statusCode: 404,
+      })
     })
 
     it("should throw non-404 errors immediately", async () => {

--- a/src/namespaces/intents.ts
+++ b/src/namespaces/intents.ts
@@ -65,8 +65,7 @@ async function waitForExecution(
     }
   }
 
-  // Retries exhausted. If the intent never materialized, surface that as a 404;
-  // otherwise return the last observed (non-terminal) state.
+  // Retries exhausted. If the intent never materialized, surface that as a 404.
   if (!lastIntent) {
     throw new CustodyError(
       { reason: `Intent ${params.intentId} not found after ${maxRetries} attempts` },
@@ -74,11 +73,12 @@ async function waitForExecution(
     )
   }
 
-  const status = lastIntent.data.state.status
+  // The loop returns early on any terminal status, so the last observed intent is
+  // necessarily non-terminal here.
   return {
-    status,
-    isTerminal: TERMINAL_STATUSES.includes(status),
-    isSuccess: status === "Executed",
+    status: lastIntent.data.state.status,
+    isTerminal: false,
+    isSuccess: false,
     intent: lastIntent,
   }
 }

--- a/src/namespaces/intents.ts
+++ b/src/namespaces/intents.ts
@@ -77,8 +77,8 @@ async function waitForExecution(
   const status = lastIntent.data.state.status
   return {
     status,
-    isTerminal: false,
-    isSuccess: false,
+    isTerminal: TERMINAL_STATUSES.includes(status),
+    isSuccess: status === "Executed",
     intent: lastIntent,
   }
 }

--- a/src/namespaces/intents.ts
+++ b/src/namespaces/intents.ts
@@ -22,65 +22,42 @@ import {
 import type { TypedTransport } from "../transport/index.js"
 
 /**
- * Fetches an intent with retry logic for 404 errors.
- * Useful when the intent might not be immediately available after creation.
- */
-async function getIntentWithRetry(
-  t: TypedTransport,
-  params: Core_GetIntentPathParams,
-  maxRetries: number,
-  intervalMs: number,
-): Promise<Core_TrustedIntent> {
-  let lastError: Error | undefined
-
-  for (let attempt = 1; attempt <= maxRetries; attempt++) {
-    try {
-      return await t.get<Core_TrustedIntent>(URLs.getIntent, params)
-    } catch (error) {
-      if (error instanceof CustodyError && error.statusCode === 404) {
-        lastError = error
-        if (attempt < maxRetries) {
-          await sleep(intervalMs)
-        }
-        continue
-      }
-      throw error
-    }
-  }
-
-  throw lastError
-}
-
-/**
  * Wait for an intent to reach a terminal status (Executed, Failed, Expired, or Rejected).
  * Polls the intent status at regular intervals until it completes or max retries is reached.
+ *
+ * A 404 is treated as "not available yet" (e.g. when called immediately after proposing)
+ * and is retried within the same polling loop rather than aborting the wait.
  */
 async function waitForExecution(
   t: TypedTransport,
   params: Core_GetIntentPathParams,
   options: WaitForExecutionOptions = {},
 ): Promise<WaitForExecutionResult> {
-  const {
-    maxRetries = 10,
-    intervalMs = 3000,
-    notFoundRetries = 3,
-    notFoundIntervalMs = 1000,
-    onStatusCheck,
-  } = options
+  const { maxRetries = 10, intervalMs = 3000, onStatusCheck } = options
+
+  let lastIntent: Core_TrustedIntent | undefined
 
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
-    const intent = await getIntentWithRetry(t, params, notFoundRetries, notFoundIntervalMs)
-    const status = intent.data.state.status
+    try {
+      const intent = await t.get<Core_TrustedIntent>(URLs.getIntent, params)
+      lastIntent = intent
+      const status = intent.data.state.status
 
-    onStatusCheck?.(status, attempt)
+      onStatusCheck?.(status, attempt)
 
-    if (TERMINAL_STATUSES.includes(status)) {
-      return {
-        status,
-        isTerminal: true,
-        isSuccess: status === "Executed",
-        intent,
+      if (TERMINAL_STATUSES.includes(status)) {
+        return {
+          status,
+          isTerminal: true,
+          isSuccess: status === "Executed",
+          intent,
+        }
       }
+    } catch (error) {
+      if (!(error instanceof CustodyError && error.statusCode === 404)) {
+        throw error
+      }
+      // 404 → the intent is not available yet, keep polling.
     }
 
     if (attempt < maxRetries) {
@@ -88,12 +65,21 @@ async function waitForExecution(
     }
   }
 
-  const finalIntent = await getIntentWithRetry(t, params, notFoundRetries, notFoundIntervalMs)
+  // Retries exhausted. If the intent never materialized, surface that as a 404;
+  // otherwise return the last observed (non-terminal) state.
+  if (!lastIntent) {
+    throw new CustodyError(
+      { reason: `Intent ${params.intentId} not found after ${maxRetries} attempts` },
+      404,
+    )
+  }
+
+  const status = lastIntent.data.state.status
   return {
-    status: finalIntent.data.state.status,
+    status,
     isTerminal: false,
     isSuccess: false,
-    intent: finalIntent,
+    intent: lastIntent,
   }
 }
 

--- a/src/services/intents/intents.types.ts
+++ b/src/services/intents/intents.types.ts
@@ -14,19 +14,14 @@ export const PENDING_STATUSES: Core_IntentStatus[] = ["Open", "Approved", "Execu
  * Options for waiting for intent execution
  */
 export type WaitForExecutionOptions = {
-  /** Maximum number of polling attempts (default: 10) */
+  /**
+   * Maximum number of polling attempts (default: 10). Also bounds how long a
+   * not-yet-available (404) intent is waited for, since 404s are retried within
+   * the same loop.
+   */
   maxRetries?: number
   /** Interval between polling attempts in milliseconds (default: 3000) */
   intervalMs?: number
-  /**
-   * Maximum number of retries when the intent is not found (404).
-   * Useful when calling immediately after proposeIntent. (default: 3)
-   */
-  notFoundRetries?: number
-  /**
-   * Interval between retries when the intent is not found in milliseconds (default: 1000)
-   */
-  notFoundIntervalMs?: number
   /**
    * Callback function called on each status check.
    * Useful for logging or updating UI.


### PR DESCRIPTION
## Problem

`intents.getAndWait` (`waitForExecution`) nested two retry loops: an inner `getIntentWithRetry` that retried on 404, wrapped by an outer status-polling loop. When the intent's 404 persisted past `notFoundRetries` (~2–3s), `getIntentWithRetry` **threw** the 404, which propagated straight out of `waitForExecution` — the outer `maxRetries`/`intervalMs` budget never got a chance. So calling `getAndWait` right after `propose` (the documented use case) could fail immediately instead of polling.

This is the same bug previously fixed for manifest polling in #86; the intents path never received the same treatment.

## Changes

- Delete `getIntentWithRetry`; `waitForExecution` is now a single loop that treats a 404 as "not available yet" and keeps polling until `maxRetries`. Non-404 errors still throw immediately.
- **Timeout path fix:** the result is derived from the last observed intent instead of a separate, unchecked extra fetch — so it can no longer report a terminal status with `isTerminal: false`/`isSuccess: false`. The redundant final network call is removed.
- **Never-found:** if every attempt 404s, throw a `CustodyError` with `statusCode: 404` after `maxRetries` (preserves the old throw-on-404 contract, now after the full poll window).
- Remove `notFoundRetries` / `notFoundIntervalMs` from `WaitForExecutionOptions` (mirrors #86's change to `WaitForSignatureOptions`).

## Tests

- Fixed the stale "+ 1 final fetch" assertion (now asserts exactly 2 GETs, no extra fetch).
- Dropped the removed options from the existing 404 test.
- Added regression coverage: keeps polling through 4 consecutive 404s then succeeds (would have thrown under the old nested limit); and rejects with `statusCode: 404` when the intent never materializes.

`vitest` → 11/11 pass. `tsc --noEmit` → no new errors (pre-existing `src/main.ts` batch errors are unrelated).

## Unrelated: release workflow (npm OIDC trusted publishing)

This PR also carries one unrelated CI commit (`4adc131`) touching `.github/workflows/release.yml`:

- Remove `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` — npm now authenticates via the OIDC token minted from the existing `id-token: write` permission.
- Add an `npm install -g npm@latest` step — Node 22 ships npm 10.x, but trusted publishing requires **npm ≥ 11.5.1**.

Follow-ups outside this PR: configure the trusted publisher on npmjs.com to point at `.github/workflows/release.yml`, and delete the now-unused `NPM_TOKEN` repo secret once verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)